### PR TITLE
feat(core): 支持通过 Core.create() 配置 WorldManager 参数

### DIFF
--- a/packages/core/src/Core.ts
+++ b/packages/core/src/Core.ts
@@ -191,7 +191,7 @@ export class Core {
         });
 
         // 初始化World管理器
-        this._worldManager = new WorldManager();
+        this._worldManager = new WorldManager(this._config.worldManagerConfig);
         this._serviceContainer.registerInstance(WorldManager, this._worldManager);
 
         // 初始化插件管理器

--- a/packages/core/src/Types/index.ts
+++ b/packages/core/src/Types/index.ts
@@ -2,6 +2,8 @@
  * 框架核心类型定义
  */
 
+import type { IWorldManagerConfig } from '../ECS';
+
 // 导出TypeScript类型增强工具
 export * from './TypeHelpers';
 export * from './IUpdatable';
@@ -264,6 +266,8 @@ export interface ICoreConfig {
     enableEntitySystems?: boolean;
     /** 调试配置 */
     debugConfig?: IECSDebugConfig;
+    /** WorldManager配置 */
+    worldManagerConfig?: IWorldManagerConfig;
 }
 
 /**


### PR DESCRIPTION
允许用户在初始化 Core 时自定义 WorldManager 的配置参数。

变更内容：

- 在 ICoreConfig 接口中新增 worldManagerConfig 可选参数
- Core 构造函数将配置传递给 WorldManager 实例化

使用示例：

```typescript
Core.create({
    debug: true,
    worldManagerConfig: {
        maxWorlds: 1000,
        autoCleanup: true,
        cleanupInterval: 60000
    }
});
```