### PR TITLE
perf(core): 优化 Scene.systems getter 避免每帧重复排序

### DIFF
--- a/packages/core/src/ECS/Systems/EntitySystem.ts
+++ b/packages/core/src/ECS/Systems/EntitySystem.ts
@@ -222,7 +222,9 @@ export abstract class EntitySystem<
      * @param order 更新时序
      */
     public setUpdateOrder(order: number): void {
+        if (this._updateOrder === order) return;
         this._updateOrder = order;
+        this._scene?.markSystemsOrderDirty();
     }
 
     /**


### PR DESCRIPTION
## 问题

Scene.systems getter 每次调用都执行排序操作；
在 update() 中每帧至少调用一次，造成不必要的性能开销；
同时 this._services.getAll() 会产生临时数组，增加GC压力；

## 解决方案

添加缓存机制：使用 _cachedSystems 缓存排序后的系统列表；
脏标记模式：使用 _systemsOrderDirty 标记系统列表是否需要重建；
在系统增删或 updateOrder 改变时标记脏，下次访问时重新排序；