### PR TITLE
fix(core): 修复 PerformanceMonitor 未遵循 Core debug 参数的问题

### DIFF
--- a/packages/core/src/Core.ts
+++ b/packages/core/src/Core.ts
@@ -191,7 +191,7 @@ export class Core {
         });
 
         // 初始化World管理器
-        this._worldManager = new WorldManager(this._config.worldManagerConfig);
+        this._worldManager = new WorldManager({ debug: !!this._config.debug, ...this._config.worldManagerConfig });
         this._serviceContainer.registerInstance(WorldManager, this._worldManager);
 
         // 初始化插件管理器

--- a/packages/core/src/ECS/Scene.ts
+++ b/packages/core/src/ECS/Scene.ts
@@ -251,7 +251,7 @@ export class Scene implements IScene {
      *
      * 从 ServiceContainer 获取，如果未注册则创建默认实例（向后兼容）
      */
-    private get performanceMonitor(): PerformanceMonitor {
+    public get performanceMonitor(): PerformanceMonitor {
         if (!this._performanceMonitor) {
             this._performanceMonitor = this._services.tryResolve(PerformanceMonitor) ?? new PerformanceMonitor();
         }

--- a/packages/core/src/ECS/World.ts
+++ b/packages/core/src/ECS/World.ts
@@ -1,6 +1,7 @@
 import { IScene } from './IScene';
 import { Scene } from './Scene';
 import { createLogger } from '../Utils/Logger';
+import { PerformanceMonitor } from '../Utils/PerformanceMonitor';
 
 const logger = createLogger('World');
 
@@ -120,6 +121,13 @@ export class World {
 
         // 如果没有提供Scene实例，创建默认Scene
         const scene = sceneInstance || (new Scene() as unknown as T);
+
+        // 如果配置了 debug，为 Scene 注册并启用 PerformanceMonitor
+        if (this._config.debug) {
+            const performanceMonitor = new PerformanceMonitor();
+            performanceMonitor.enable();
+            scene.services.registerInstance(PerformanceMonitor, performanceMonitor);
+        }
 
         // 设置Scene的标识
         if ('id' in scene) {

--- a/packages/core/src/ECS/WorldManager.ts
+++ b/packages/core/src/ECS/WorldManager.ts
@@ -108,9 +108,10 @@ export class WorldManager implements IService {
             throw new Error(`已达到最大World数量限制: ${this._config.maxWorlds}`);
         }
 
+        // 优先级：config.debug > WorldManager.debug > 默认
         const worldConfig: IWorldConfig = {
             name: worldId,
-            ...(this._config.debug !== undefined && { debug: this._config.debug }),
+            debug: config?.debug ?? this._config.debug ?? false,
             ...(config?.maxScenes !== undefined && { maxScenes: config.maxScenes }),
             ...(config?.autoCleanup !== undefined && { autoCleanup: config.autoCleanup })
         };


### PR DESCRIPTION
问题：在 Core.create({ debug: true }) 时，Scene 的 PerformanceMonitor 并没有遵循 Core debug 参数开启性能监控。

- Core 传递 debug 配置到 WorldManager
- WorldManager 传递 debug 配置到 World
- World 在 debug=true 时为 Scene 注册并启用 PerformanceMonitor
- new Scene 的情况默认未开启，但暴露了 `performanceMonitor` 由使用者处理