### PR TITLE
fix(docs): 修复英文文档dead links问题

### DIFF
--- a/docs/en/guide/getting-started.md
+++ b/docs/en/guide/getting-started.md
@@ -387,8 +387,8 @@ export class ECSGameManager extends Component {
 
 You've successfully created your first ECS application! Next you can:
 
-- Check the complete [API Documentation](/en/api/README)
-- Explore more [practical examples](/en/examples/)
+- Check the complete [API Documentation](/api/README)
+- Explore more [practical examples](/examples/)
 
 ## FAQ
 

--- a/docs/en/guide/index.md
+++ b/docs/en/guide/index.md
@@ -4,40 +4,40 @@ Welcome to the ECS Framework Guide. This guide covers the core concepts and usag
 
 ## Core Concepts
 
-### [Entity](./entity.md)
+### [Entity](/guide/entity)
 Learn the basics of ECS architecture - how to use entities, lifecycle management, and best practices.
 
-### [Component](./component.md)
+### [Component](/guide/component)
 Learn how to create and use components for modular game feature design.
 
-### [System](./system.md)
+### [System](/guide/system)
 Master system development to implement game logic processing.
 
-### [Entity Query & Matcher](./entity-query.md)
+### [Entity Query & Matcher](/guide/entity-query)
 Learn to use Matcher for entity filtering and queries with `all`, `any`, `none`, `nothing` conditions.
 
-### [Scene](./scene.md)
+### [Scene](/guide/scene)
 Understand scene lifecycle, system management, and entity container features.
 
-### [Event System](./event-system.md)
+### [Event System](/guide/event-system)
 Master the type-safe event system for component communication and system coordination.
 
-### [Serialization](./serialization.md)
+### [Serialization](/guide/serialization)
 Master serialization for scenes, entities, and components. Supports full and incremental serialization for game saves, network sync, and more.
 
-### [Time and Timers](./time-and-timers.md)
+### [Time and Timers](/guide/time-and-timers)
 Learn time management and timer systems for precise game logic timing control.
 
-### [Logging](./logging.md)
+### [Logging](/guide/logging)
 Master the leveled logging system for debugging, monitoring, and error tracking.
 
-### [Platform Adapter](./platform-adapter.md)
+### [Platform Adapter](/guide/platform-adapter)
 Learn how to implement and register platform adapters for browsers, mini-games, Node.js, and more.
 
 ## Advanced Features
 
-### [Service Container](./service-container.md)
+### [Service Container](/guide/service-container)
 Master dependency injection and service management for loosely-coupled architecture.
 
-### [Plugin System](./plugin-system.md)
+### [Plugin System](/guide/plugin-system)
 Learn how to develop and use plugins to extend framework functionality.


### PR DESCRIPTION
## Summary
修复英文版文档中的dead links，解决docs:build构建失败问题。

## Changes
- 将英文guide/index.md中的相对链接改为指向中文文档的绝对路径
- 修复getting-started.md中的API和examples链接

## Issue
CI构建时报错：`14 dead link(s) found`