### PR TITLE
fix: 修复系统 onAdded 回调受注册顺序影响的问题

### DIFF
--- a/packages/core/src/ECS/Entity.ts
+++ b/packages/core/src/ECS/Entity.ts
@@ -321,11 +321,19 @@ export class Entity {
 
     /**
      * 通知Scene中的QuerySystem实体组件发生变动
+     *
+     * Notify the QuerySystem in Scene that entity components have changed
+     *
+     * @param changedComponentType 变化的组件类型（可选，用于优化通知） | Changed component type (optional, for optimized notification)
      */
-    private notifyQuerySystems(): void {
+    private notifyQuerySystems(changedComponentType?: ComponentType): void {
         if (this.scene && this.scene.querySystem) {
             this.scene.querySystem.updateEntity(this);
             this.scene.clearSystemEntityCaches();
+            // 事件驱动：立即通知关心该组件的系统 | Event-driven: notify systems that care about this component
+            if (this.scene.notifyEntityComponentChanged) {
+                this.scene.notifyEntityComponentChanged(this, changedComponentType);
+            }
         }
     }
 
@@ -381,7 +389,7 @@ export class Entity {
             });
         }
 
-        this.notifyQuerySystems();
+        this.notifyQuerySystems(componentType);
 
         return component;
     }
@@ -514,7 +522,7 @@ export class Entity {
             });
         }
 
-        this.notifyQuerySystems();
+        this.notifyQuerySystems(componentType);
     }
 
     /**

--- a/packages/core/src/ECS/IScene.ts
+++ b/packages/core/src/ECS/IScene.ts
@@ -2,7 +2,7 @@ import { Entity } from './Entity';
 import { EntityList } from './Utils/EntityList';
 import { IdentifierPool } from './Utils/IdentifierPool';
 import { EntitySystem } from './Systems/EntitySystem';
-import { ComponentStorageManager } from './Core/ComponentStorage';
+import { ComponentStorageManager, ComponentType } from './Core/ComponentStorage';
 import { QuerySystem } from './Core/QuerySystem';
 import { TypeSafeEventSystem } from './Core/EventSystem';
 import type { ReferenceTracker } from './Core/ReferenceTracker';
@@ -120,8 +120,25 @@ export interface IScene {
 
     /**
      * 清除所有EntitySystem的实体缓存
+     * Clear all EntitySystem entity caches
      */
     clearSystemEntityCaches(): void;
+
+    /**
+     * 通知相关系统实体的组件发生了变化
+     *
+     * 当组件被添加或移除时调用，立即通知相关系统检查该实体是否匹配，
+     * 并触发 onAdded/onRemoved 回调。通过组件ID索引优化，只通知关心该组件的系统。
+     *
+     * Notify relevant systems that an entity's components have changed.
+     * Called when a component is added or removed, immediately notifying
+     * relevant systems to check if the entity matches and trigger onAdded/onRemoved callbacks.
+     * Optimized via component ID indexing to only notify systems that care about the changed component.
+     *
+     * @param entity 组件发生变化的实体 | The entity whose components changed
+     * @param changedComponentType 变化的组件类型（可选） | The changed component type (optional)
+     */
+    notifyEntityComponentChanged(entity: Entity, changedComponentType?: ComponentType): void;
 
     /**
      * 添加实体


### PR DESCRIPTION
## 问题

当 SystemA 在 `process()` 中添加组件时，如果 SystemB 先于 SystemA 注册，SystemB 的 `onAdded` 回调不会被触发。

## 解决方案

采用事件驱动设计，组件变化时立即通知相关系统：

- 添加 `handleEntityComponentChanged` 方法处理实时组件变化
- 添加 `matchesEntity` 和 `isTracking` 辅助方法
- 使用组件ID索引优化通知性能，只通知关心该组件的系统

## 优化细节

- `_componentIdToSystems`: 按组件ID索引的系统映射
- `_globalNotifySystems`: 需要接收所有通知的系统（none/tag/name条件）
- `Scene.end()` 时正确清理索引，避免内存泄漏