### PR TITLE
feat(editor): 实现用户脚本编译加载和自动重编译

### DIFF
--- a/packages/core/src/Platform/PlatformDetector.ts
+++ b/packages/core/src/Platform/PlatformDetector.ts
@@ -189,6 +189,46 @@ export class PlatformDetector {
     }
 
     /**
+     * 检测是否在 Tauri 桌面环境中运行
+     * Check if running in Tauri desktop environment
+     *
+     * 同时支持 Tauri v1 (__TAURI__) 和 v2 (__TAURI_INTERNALS__)
+     * Supports both Tauri v1 (__TAURI__) and v2 (__TAURI_INTERNALS__)
+     */
+    public static isTauriEnvironment(): boolean {
+        if (typeof window === 'undefined') {
+            return false;
+        }
+        // Tauri v1 uses __TAURI__, Tauri v2 uses __TAURI_INTERNALS__
+        return '__TAURI__' in window || '__TAURI_INTERNALS__' in window;
+    }
+
+    /**
+     * 检测是否在编辑器环境中运行
+     * Check if running in editor environment
+     *
+     * 包括 Tauri 桌面应用或带 __ESENGINE_EDITOR__ 标记的环境
+     * Includes Tauri desktop app or environments marked with __ESENGINE_EDITOR__
+     */
+    public static isEditorEnvironment(): boolean {
+        if (typeof window === 'undefined') {
+            return false;
+        }
+
+        // Tauri desktop app | Tauri 桌面应用
+        if (this.isTauriEnvironment()) {
+            return true;
+        }
+
+        // Editor marker | 编辑器标记
+        if ('__ESENGINE_EDITOR__' in window) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
      * 获取详细的环境信息（用于调试）
      */
     public static getDetailedInfo(): Record<string, any> {

--- a/packages/editor-app/src-tauri/src/commands/file_system.rs
+++ b/packages/editor-app/src-tauri/src/commands/file_system.rs
@@ -82,10 +82,35 @@ pub fn delete_file(path: String) -> Result<(), String> {
 }
 
 /// Delete directory (recursive)
+/// 递归删除目录
 #[tauri::command]
 pub fn delete_folder(path: String) -> Result<(), String> {
-    fs::remove_dir_all(&path)
-        .map_err(|e| format!("Failed to delete folder {}: {}", path, e))
+    println!("[delete_folder] Attempting to delete: {}", path);
+
+    // Check if path exists
+    // 检查路径是否存在
+    let dir_path = std::path::Path::new(&path);
+    if !dir_path.exists() {
+        println!("[delete_folder] Path does not exist: {}", path);
+        return Err(format!("Directory does not exist: {}", path));
+    }
+
+    if !dir_path.is_dir() {
+        println!("[delete_folder] Path is not a directory: {}", path);
+        return Err(format!("Path is not a directory: {}", path));
+    }
+
+    match fs::remove_dir_all(&path) {
+        Ok(_) => {
+            println!("[delete_folder] Successfully deleted: {}", path);
+            Ok(())
+        }
+        Err(e) => {
+            let error_msg = format!("Failed to delete folder {}: {}", path, e);
+            eprintln!("[delete_folder] Error: {}", error_msg);
+            Err(error_msg)
+        }
+    }
 }
 
 /// Rename or move file/folder

--- a/packages/editor-app/src-tauri/src/main.rs
+++ b/packages/editor-app/src-tauri/src/main.rs
@@ -82,7 +82,7 @@ fn main() {
             commands::show_in_folder,
             commands::get_temp_dir,
             commands::open_with_editor,
-            commands::copy_type_definitions,
+            commands::update_project_tsconfig,
             commands::get_app_resource_dir,
             commands::get_current_dir,
             commands::start_local_server,
@@ -156,7 +156,13 @@ fn handle_project_protocol(
             tauri::http::Response::builder()
                 .status(200)
                 .header("Content-Type", mime_type)
+                // CORS headers for dynamic ES module imports | 动态 ES 模块导入所需的 CORS 头
                 .header("Access-Control-Allow-Origin", "*")
+                .header("Access-Control-Allow-Methods", "GET, OPTIONS")
+                .header("Access-Control-Allow-Headers", "Content-Type")
+                .header("Access-Control-Expose-Headers", "Content-Length")
+                // Allow cross-origin script loading | 允许跨域脚本加载
+                .header("Cross-Origin-Resource-Policy", "cross-origin")
                 .body(content)
                 .unwrap()
         }
@@ -164,6 +170,7 @@ fn handle_project_protocol(
             eprintln!("Failed to read file {}: {}", file_path, e);
             tauri::http::Response::builder()
                 .status(404)
+                .header("Access-Control-Allow-Origin", "*")
                 .body(Vec::new())
                 .unwrap()
         }

--- a/packages/editor-app/src/App.tsx
+++ b/packages/editor-app/src/App.tsx
@@ -381,12 +381,12 @@ function App() {
             // 设置 Tauri project:// 协议的基础路径（用于加载插件等项目文件）
             await TauriAPI.setProjectBasePath(projectPath);
 
-            // 复制类型定义到项目，用于 IDE 智能感知
-            // Copy type definitions to project for IDE intellisense
+            // 更新项目 tsconfig，直接引用引擎类型定义
+            // Update project tsconfig to reference engine type definitions directly
             try {
-                await TauriAPI.copyTypeDefinitions(projectPath);
+                await TauriAPI.updateProjectTsconfig(projectPath);
             } catch (e) {
-                console.warn('[App] Failed to copy type definitions:', e);
+                console.warn('[App] Failed to update project tsconfig:', e);
             }
 
             const settings = SettingsService.getInstance();
@@ -840,14 +840,17 @@ function App() {
                         setStatus(t('header.status.ready'));
                     }}
                     onDeleteProject={async (projectPath) => {
+                        console.log('[App] onDeleteProject called with path:', projectPath);
                         try {
+                            console.log('[App] Calling TauriAPI.deleteFolder...');
                             await TauriAPI.deleteFolder(projectPath);
+                            console.log('[App] deleteFolder succeeded');
                             // 删除成功后从列表中移除并触发重新渲染
                             // Remove from list and trigger re-render after successful deletion
                             settings.removeRecentProject(projectPath);
                             setStatus(t('header.status.ready'));
                         } catch (error) {
-                            console.error('Failed to delete project:', error);
+                            console.error('[App] Failed to delete project:', error);
                             setErrorDialog({
                                 title: locale === 'zh' ? '删除项目失败' : 'Failed to Delete Project',
                                 message: locale === 'zh'

--- a/packages/editor-app/src/api/tauri.ts
+++ b/packages/editor-app/src/api/tauri.ts
@@ -332,13 +332,17 @@ export class TauriAPI {
     }
 
     /**
-     * 复制类型定义文件到项目
-     * Copy type definition files to project for IDE intellisense
+     * 更新项目的 tsconfig.json，添加引擎类型路径
+     * Update project tsconfig.json with engine type paths
+     *
+     * This updates the tsconfig to point directly to engine's .d.ts files
+     * instead of copying them to the project.
+     * 这会更新 tsconfig 直接指向引擎的 .d.ts 文件，而不是复制到项目。
      *
      * @param projectPath 项目路径 | Project path
      */
-    static async copyTypeDefinitions(projectPath: string): Promise<void> {
-        return await invoke<void>('copy_type_definitions', { projectPath });
+    static async updateProjectTsconfig(projectPath: string): Promise<void> {
+        return await invoke<void>('update_project_tsconfig', { projectPath });
     }
 
     /**

--- a/packages/editor-app/src/components/StartupPage.tsx
+++ b/packages/editor-app/src/components/StartupPage.tsx
@@ -310,7 +310,12 @@ export function StartupPage({ onOpenProject, onCreateProject, onOpenRecentProjec
                                 className="startup-dialog-btn danger"
                                 onClick={async () => {
                                     if (deleteConfirm && onDeleteProject) {
-                                        await onDeleteProject(deleteConfirm);
+                                        try {
+                                            await onDeleteProject(deleteConfirm);
+                                        } catch (error) {
+                                            console.error('[StartupPage] Failed to delete project:', error);
+                                            // Error will be handled by App.tsx error dialog
+                                        }
                                     }
                                     setDeleteConfirm(null);
                                 }}

--- a/packages/editor-app/src/styles/ContentBrowser.css
+++ b/packages/editor-app/src/styles/ContentBrowser.css
@@ -6,6 +6,7 @@
     background: #1e1e1e;
     color: #e0e0e0;
     font-size: 12px;
+    outline: none;
 }
 
 .content-browser.is-drawer {

--- a/packages/editor-core/src/Services/ProjectService.ts
+++ b/packages/editor-core/src/Services/ProjectService.ts
@@ -130,13 +130,10 @@ export class ProjectService implements IService {
             const assetsPath = `${projectPath}${sep}assets`;
             await this.fileAPI.createDirectory(assetsPath);
 
-            // Create types folder for type definitions
-            // 创建类型定义文件夹
-            const typesPath = `${projectPath}${sep}types`;
-            await this.fileAPI.createDirectory(typesPath);
-
-            // Create tsconfig.json for TypeScript support
-            // 创建 tsconfig.json 用于 TypeScript 支持
+            // Create tsconfig.json for runtime scripts (components, systems)
+            // 创建运行时脚本的 tsconfig.json（组件、系统等）
+            // Note: paths will be populated by update_project_tsconfig when project is opened
+            // 注意：paths 会在项目打开时由 update_project_tsconfig 填充
             const tsConfig = {
                 compilerOptions: {
                     target: 'ES2020',
@@ -149,20 +146,39 @@ export class ProjectService implements IService {
                     forceConsistentCasingInFileNames: true,
                     experimentalDecorators: true,
                     emitDecoratorMetadata: true,
-                    noEmit: true,
-                    // Reference local type definitions
-                    // 引用本地类型定义文件
-                    typeRoots: ['./types'],
-                    paths: {
-                        '@esengine/ecs-framework': ['./types/ecs-framework.d.ts'],
-                        '@esengine/engine-core': ['./types/engine-core.d.ts']
-                    }
+                    noEmit: true
+                    // paths will be added by editor when project is opened
+                    // paths 会在编辑器打开项目时添加
                 },
                 include: ['scripts/**/*.ts'],
-                exclude: ['.esengine']
+                exclude: ['scripts/editor/**/*.ts', '.esengine']
             };
             const tsConfigPath = `${projectPath}${sep}tsconfig.json`;
             await this.fileAPI.writeFileContent(tsConfigPath, JSON.stringify(tsConfig, null, 2));
+
+            // Create tsconfig.editor.json for editor extension scripts
+            // 创建编辑器扩展脚本的 tsconfig.editor.json
+            const tsConfigEditor = {
+                compilerOptions: {
+                    target: 'ES2020',
+                    module: 'ESNext',
+                    moduleResolution: 'bundler',
+                    lib: ['ES2020', 'DOM'],
+                    strict: true,
+                    esModuleInterop: true,
+                    skipLibCheck: true,
+                    forceConsistentCasingInFileNames: true,
+                    experimentalDecorators: true,
+                    emitDecoratorMetadata: true,
+                    noEmit: true
+                    // paths will be added by editor when project is opened
+                    // paths 会在编辑器打开项目时添加
+                },
+                include: ['scripts/editor/**/*.ts'],
+                exclude: ['.esengine']
+            };
+            const tsConfigEditorPath = `${projectPath}${sep}tsconfig.editor.json`;
+            await this.fileAPI.writeFileContent(tsConfigEditorPath, JSON.stringify(tsConfigEditor, null, 2));
 
             await this.messageHub.publish('project:created', {
                 path: projectPath

--- a/packages/editor-core/src/Services/UserCode/IUserCodeService.ts
+++ b/packages/editor-core/src/Services/UserCode/IUserCodeService.ts
@@ -215,8 +215,9 @@ export interface IUserCodeService {
      * - Classes extending System
      *
      * @param module - User code module | 用户代码模块
+     * @param componentRegistry - Optional ComponentRegistry to register components | 可选的 ComponentRegistry 用于注册组件
      */
-    registerComponents(module: UserCodeModule): void;
+    registerComponents(module: UserCodeModule, componentRegistry?: any): void;
 
     /**
      * Register editor extensions from user module.


### PR DESCRIPTION
## Summary
- 实现 Tauri 编辑器中用户脚本的编译和加载
- 使用 IIFE 格式和模块 alias/shim 解决 CORS 和模块解析问题
- 支持脚本创建/删除时自动重新编译
- 删除文件时同时删除对应的 .meta 文件
- 使用原型链检查识别用户组件类