### PR TITLE
fix(docs): 修正 v2.2.16 组件生命周期描述

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -84,9 +84,7 @@
 ### Features
 
 - **组件生命周期**: 添加组件生命周期回调支持 (#237)
-  - `onEnable()`: 组件启用时调用
-  - `onDisable()`: 组件禁用时调用
-  - `onDestroy()`: 组件销毁时调用
+  - `onDeserialized()`: 组件从场景文件加载或快照恢复后调用，用于恢复运行时数据
 
 - **ServiceContainer 增强**: 改进服务容器功能 (#237)
   - 支持 `Symbol.for()` 模式的服务标识

--- a/docs/en/changelog.md
+++ b/docs/en/changelog.md
@@ -84,9 +84,7 @@ This document records the version update history of the `@esengine/ecs-framework
 ### Features
 
 - **Component lifecycle**: Add component lifecycle callback support (#237)
-  - `onEnable()`: Called when component is enabled
-  - `onDisable()`: Called when component is disabled
-  - `onDestroy()`: Called when component is destroyed
+  - `onDeserialized()`: Called after component is loaded from scene file or snapshot restore, used to restore runtime data
 
 - **ServiceContainer enhancement**: Improve service container functionality (#237)
   - Support `Symbol.for()` pattern for service identifiers


### PR DESCRIPTION
修正 changelog 中 v2.2.16 组件生命周期的描述错误。

实际添加的是 `onDeserialized()` 方法，不是 `onEnable`/`onDisable`/`onDestroy`。