### PR TITLE
fix(editor): 修复 Play/Stop 循环中的场景管理器和动态实体问题

### DIFF
--- a/packages/core/src/ECS/Utils/EntityList.ts
+++ b/packages/core/src/ECS/Utils/EntityList.ts
@@ -80,17 +80,30 @@ export class EntityList {
 
     /**
      * 移除所有实体
+     * Remove all entities
+     *
+     * 包括 buffer 中的实体和待添加队列中的实体。
+     * Includes entities in buffer and entities in pending add queue.
      */
     public removeAllEntities(): void {
-        // 收集所有实体ID用于回收
         const idsToRecycle: number[] = [];
 
+        // 销毁 buffer 中的实体
+        // Destroy entities in buffer
         for (let i = this.buffer.length - 1; i >= 0; i--) {
             idsToRecycle.push(this.buffer[i]!.id);
             this.buffer[i]!.destroy();
         }
 
-        // 批量回收ID
+        // 销毁待添加队列中的实体（这些实体已创建但尚未加入 buffer）
+        // Destroy entities in pending add queue (created but not yet in buffer)
+        for (const entity of this._entitiesToAdd) {
+            idsToRecycle.push(entity.id);
+            entity.destroy();
+        }
+
+        // 批量回收 ID
+        // Recycle IDs in batch
         if (this._scene && this._scene.identifierPool) {
             for (const id of idsToRecycle) {
                 this._scene.identifierPool.checkIn(id);


### PR DESCRIPTION
## Summary

修复编辑器 Play/Stop 循环中的三个关键问题：

1. **RuntimeSceneManager 第二次 Play 失效**
   - 根因：SceneLoadTriggerSystem 闭包缓存了 sceneManager 引用，Stop 后引用失效
   - 修复：每次点击时动态从 Core.services 获取服务

2. **动态创建的实体（如 ClickFx 粒子）Stop 后残留**
   - 根因：EntityList.removeAllEntities() 只清空 _entitiesToAdd 队列但没有销毁实体
   - 修复：先销毁待添加队列中的实体再清空

3. **场景切换后动态实体残留**
   - 根因：editorSceneLoader 中 saveSceneSnapshot() 覆盖了初始快照
   - 修复：移除该调用，保持 Play 开始时的快照不被覆盖

## 架构改进

- RuntimeSceneManager 新增 `reset()` 方法，区分会话重置和完全销毁
- Viewport 复用 RuntimeSceneManager 实例而非每次创建
- IRuntimeSceneManager 接口补充 `setSceneLoader`/`setBaseUrl` 方法

## 修改文件

| 文件 | 修改内容 |
|------|----------|
| `packages/ui/src/systems/SceneLoadTriggerSystem.ts` | 每次点击动态获取服务 |
| `packages/core/src/ECS/Utils/EntityList.ts` | 销毁待添加队列中的实体 |
| `packages/runtime-core/src/services/RuntimeSceneManager.ts` | 添加 reset() 方法和接口 |
| `packages/editor-app/src/components/Viewport.tsx` | 复用实例、移除错误的快照保存 |

## Test plan

- [x] Play → 点击创建 ClickFx → Stop → 确认 ClickFx 实体已清理
- [x] Play → 切换场景 → 点击创建 ClickFx → Stop → 确认恢复到初始场景
- [x] 多次 Play/Stop 循环，确认 RuntimeSceneManager 正常工作