### PR TITLE
refactor(render): 统一渲染API并修复双重渲染问题

### DIFF
--- a/packages/ecs-engine-bindgen/src/core/RenderBatcher.ts
+++ b/packages/ecs-engine-bindgen/src/core/RenderBatcher.ts
@@ -1,106 +1,386 @@
 /**
- * Render batcher for collecting sprite data.
- * 用于收集精灵数据的渲染批处理器。
+ * High-performance render batcher using Structure of Arrays (SoA) pattern.
+ * 使用结构数组 (SoA) 模式的高性能渲染批处理器。
+ *
+ * Optimizations:
+ * 优化：
+ * - Pre-allocated typed arrays to avoid per-frame GC
+ *   预分配类型数组以避免每帧 GC
+ * - SoA layout for cache-friendly access
+ *   SoA 布局提供缓存友好的访问
+ * - Object pool for SpriteRenderData when interface compatibility is needed
+ *   当需要接口兼容性时使用 SpriteRenderData 对象池
  */
 
-import type { SpriteRenderData } from '../types';
+import type { SpriteRenderData, MaterialOverrides } from '../types';
 
 /**
- * Collects and sorts sprite render data for batch submission.
- * 收集和排序精灵渲染数据用于批量提交。
- *
- * This class is used to collect sprites during the ECS update loop
- * and then submit them all at once to the engine.
- * 此类用于在ECS更新循环中收集精灵，然后一次性提交到引擎。
+ * Default maximum sprites per batch.
+ * 默认每批次最大精灵数。
+ */
+const DEFAULT_MAX_SPRITES = 10000;
+
+/**
+ * High-performance render batcher with SoA storage.
+ * 使用 SoA 存储的高性能渲染批处理器。
  *
  * @example
  * ```typescript
- * const batcher = new RenderBatcher();
+ * const batcher = new RenderBatcher(10000);
  *
- * // During ECS update | 在ECS更新期间
- * batcher.addSprite({
- *     x: 100, y: 200,
- *     rotation: 0,
- *     scaleX: 1, scaleY: 1,
- *     originX: 0.5, originY: 0.5,
- *     textureId: 1,
- *     uv: [0, 0, 1, 1],
- *     color: 0xFFFFFFFF
- * });
+ * // Add sprites using SoA API (fastest) | 使用 SoA API 添加精灵（最快）
+ * batcher.addSpriteSoA(x, y, rot, sx, sy, ox, oy, texId, u0, v0, u1, v1, color, matId);
  *
- * // At end of frame | 在帧结束时
- * bridge.submitSprites(batcher.getSprites());
+ * // Or use object API for compatibility | 或使用对象 API 以保持兼容性
+ * batcher.addSprite(spriteData);
+ *
+ * // Get typed arrays for submission | 获取类型数组用于提交
+ * const { transforms, textureIds, uvs, colors, materialIds, count } = batcher.getBuffers();
+ *
+ * // At end of frame | 帧结束时
  * batcher.clear();
  * ```
  */
 export class RenderBatcher {
-    private sprites: SpriteRenderData[] = [];
+    // ===== SoA Buffers (pre-allocated) =====
+    // ===== SoA 缓冲区（预分配）=====
+
+    /** Transform data: [x, y, rotation, scaleX, scaleY, originX, originY] per sprite */
+    private _transforms: Float32Array;
+
+    /** Texture IDs | 纹理 ID */
+    private _textureIds: Uint32Array;
+
+    /** UV coordinates: [u0, v0, u1, v1] per sprite */
+    private _uvs: Float32Array;
+
+    /** Packed RGBA colors | 打包的 RGBA 颜色 */
+    private _colors: Uint32Array;
+
+    /** Material IDs | 材质 ID */
+    private _materialIds: Uint32Array;
+
+    /** Current sprite count | 当前精灵数量 */
+    private _count: number = 0;
+
+    /** Maximum sprites capacity | 最大精灵容量 */
+    private _capacity: number;
+
+    // ===== Object Pool for SpriteRenderData compatibility =====
+    // ===== SpriteRenderData 对象池用于兼容性 =====
+
+    /** Pool of reusable SpriteRenderData objects | 可复用的 SpriteRenderData 对象池 */
+    private _spritePool: SpriteRenderData[] = [];
+
+    /** Current pool index | 当前池索引 */
+    private _poolIndex: number = 0;
+
+    // ===== Material Overrides Storage =====
+    // ===== 材质覆盖存储 =====
+
+    /** Material overrides by sprite index | 按精灵索引存储的材质覆盖 */
+    private _materialOverrides: Map<number, MaterialOverrides> = new Map();
+
+    /** Clip rects by sprite index | 按精灵索引存储的裁剪矩形 */
+    private _clipRects: Map<number, { x: number; y: number; width: number; height: number }> = new Map();
 
     /**
-     * Create a new render batcher.
-     * 创建新的渲染批处理器。
+     * Create a new render batcher with pre-allocated buffers.
+     * 创建具有预分配缓冲区的新渲染批处理器。
      *
-     * Sprites are stored in insertion order. The caller is responsible
-     * for adding sprites in the correct render order (back-to-front for 2D).
-     * 精灵按插入顺序存储。调用者负责以正确的渲染顺序添加精灵（2D 中从后到前）。
+     * @param capacity - Maximum sprites (default: 10000) | 最大精灵数（默认：10000）
      */
-    constructor() {}
+    constructor(capacity: number = DEFAULT_MAX_SPRITES) {
+        this._capacity = capacity;
+
+        // Pre-allocate all buffers | 预分配所有缓冲区
+        this._transforms = new Float32Array(capacity * 7);
+        this._textureIds = new Uint32Array(capacity);
+        this._uvs = new Float32Array(capacity * 4);
+        this._colors = new Uint32Array(capacity);
+        this._materialIds = new Uint32Array(capacity);
+
+        // Pre-populate object pool | 预填充对象池
+        this._initPool();
+    }
 
     /**
-     * Add a sprite to the batch.
-     * 将精灵添加到批处理。
+     * Initialize the object pool with reusable objects.
+     * 使用可复用对象初始化对象池。
+     */
+    private _initPool(): void {
+        // Create a smaller initial pool, expand on demand
+        // 创建较小的初始池，按需扩展
+        const initialPoolSize = Math.min(1000, this._capacity);
+        for (let i = 0; i < initialPoolSize; i++) {
+            this._spritePool.push(this._createSpriteData());
+        }
+    }
+
+    /**
+     * Create a new SpriteRenderData object.
+     * 创建新的 SpriteRenderData 对象。
+     */
+    private _createSpriteData(): SpriteRenderData {
+        return {
+            x: 0,
+            y: 0,
+            rotation: 0,
+            scaleX: 1,
+            scaleY: 1,
+            originX: 0.5,
+            originY: 0.5,
+            textureId: 0,
+            uv: [0, 0, 1, 1],
+            color: 0xFFFFFFFF,
+            materialId: 0
+        };
+    }
+
+    /**
+     * Get a SpriteRenderData object from pool.
+     * 从池中获取 SpriteRenderData 对象。
+     */
+    private _getFromPool(): SpriteRenderData {
+        if (this._poolIndex >= this._spritePool.length) {
+            // Expand pool | 扩展池
+            this._spritePool.push(this._createSpriteData());
+        }
+        return this._spritePool[this._poolIndex++];
+    }
+
+    // ===== High-Performance SoA API =====
+    // ===== 高性能 SoA API =====
+
+    /**
+     * Add a sprite using direct SoA parameters (fastest method).
+     * 使用直接 SoA 参数添加精灵（最快方法）。
+     *
+     * @returns Sprite index for additional data (overrides, clipRect) | 精灵索引用于附加数据
+     */
+    addSpriteSoA(
+        x: number,
+        y: number,
+        rotation: number,
+        scaleX: number,
+        scaleY: number,
+        originX: number,
+        originY: number,
+        textureId: number,
+        u0: number,
+        v0: number,
+        u1: number,
+        v1: number,
+        color: number,
+        materialId: number = 0
+    ): number {
+        if (this._count >= this._capacity) {
+            console.warn('RenderBatcher capacity exceeded | RenderBatcher 容量已满');
+            return -1;
+        }
+
+        const i = this._count;
+        const tOffset = i * 7;
+        const uvOffset = i * 4;
+
+        // Write transform data | 写入变换数据
+        this._transforms[tOffset] = x;
+        this._transforms[tOffset + 1] = y;
+        this._transforms[tOffset + 2] = rotation;
+        this._transforms[tOffset + 3] = scaleX;
+        this._transforms[tOffset + 4] = scaleY;
+        this._transforms[tOffset + 5] = originX;
+        this._transforms[tOffset + 6] = originY;
+
+        // Write texture ID | 写入纹理 ID
+        this._textureIds[i] = textureId;
+
+        // Write UV coordinates | 写入 UV 坐标
+        this._uvs[uvOffset] = u0;
+        this._uvs[uvOffset + 1] = v0;
+        this._uvs[uvOffset + 2] = u1;
+        this._uvs[uvOffset + 3] = v1;
+
+        // Write color and material | 写入颜色和材质
+        this._colors[i] = color;
+        this._materialIds[i] = materialId;
+
+        this._count++;
+        return i;
+    }
+
+    /**
+     * Set material overrides for a sprite.
+     * 为精灵设置材质覆盖。
+     *
+     * @param index - Sprite index from addSpriteSoA | 来自 addSpriteSoA 的精灵索引
+     * @param overrides - Material overrides | 材质覆盖
+     */
+    setMaterialOverrides(index: number, overrides: MaterialOverrides): void {
+        if (index >= 0 && index < this._count) {
+            this._materialOverrides.set(index, overrides);
+        }
+    }
+
+    /**
+     * Set clip rect for a sprite.
+     * 为精灵设置裁剪矩形。
+     *
+     * @param index - Sprite index from addSpriteSoA | 来自 addSpriteSoA 的精灵索引
+     * @param clipRect - Clip rectangle | 裁剪矩形
+     */
+    setClipRect(index: number, clipRect: { x: number; y: number; width: number; height: number }): void {
+        if (index >= 0 && index < this._count) {
+            this._clipRects.set(index, clipRect);
+        }
+    }
+
+    // ===== Object API (for compatibility) =====
+    // ===== 对象 API（用于兼容性）=====
+
+    /**
+     * Add a sprite using SpriteRenderData object.
+     * 使用 SpriteRenderData 对象添加精灵。
+     *
+     * This method is kept for backward compatibility but internally uses SoA storage.
+     * 此方法保留用于向后兼容，但内部使用 SoA 存储。
      *
      * @param sprite - Sprite render data | 精灵渲染数据
      */
     addSprite(sprite: SpriteRenderData): void {
-        this.sprites.push(sprite);
+        const index = this.addSpriteSoA(
+            sprite.x,
+            sprite.y,
+            sprite.rotation,
+            sprite.scaleX,
+            sprite.scaleY,
+            sprite.originX,
+            sprite.originY,
+            sprite.textureId,
+            sprite.uv[0],
+            sprite.uv[1],
+            sprite.uv[2],
+            sprite.uv[3],
+            sprite.color,
+            sprite.materialId ?? 0
+        );
+
+        // Store optional data | 存储可选数据
+        if (index >= 0) {
+            if (sprite.materialOverrides) {
+                this._materialOverrides.set(index, sprite.materialOverrides);
+            }
+            if (sprite.clipRect) {
+                this._clipRects.set(index, sprite.clipRect);
+            }
+        }
     }
 
     /**
-     * Add multiple sprites to the batch.
-     * 将多个精灵添加到批处理。
+     * Add multiple sprites.
+     * 添加多个精灵。
      *
      * @param sprites - Array of sprite render data | 精灵渲染数据数组
      */
     addSprites(sprites: SpriteRenderData[]): void {
-        this.sprites.push(...sprites);
+        for (let i = 0; i < sprites.length; i++) {
+            this.addSprite(sprites[i]);
+        }
+    }
+
+    // ===== Buffer Access =====
+    // ===== 缓冲区访问 =====
+
+    /**
+     * Get raw typed array buffers for direct submission to engine.
+     * 获取原始类型数组缓冲区以直接提交到引擎。
+     *
+     * Returns subarray views (zero-copy) for only the used portion.
+     * 返回仅已使用部分的 subarray 视图（零拷贝）。
+     */
+    getBuffers(): {
+        transforms: Float32Array;
+        textureIds: Uint32Array;
+        uvs: Float32Array;
+        colors: Uint32Array;
+        materialIds: Uint32Array;
+        count: number;
+    } {
+        return {
+            transforms: this._transforms.subarray(0, this._count * 7),
+            textureIds: this._textureIds.subarray(0, this._count),
+            uvs: this._uvs.subarray(0, this._count * 4),
+            colors: this._colors.subarray(0, this._count),
+            materialIds: this._materialIds.subarray(0, this._count),
+            count: this._count
+        };
     }
 
     /**
-     * Get all sprites in the batch.
-     * 获取批处理中的所有精灵。
+     * Get sprites as SpriteRenderData array (for legacy compatibility).
+     * 获取精灵作为 SpriteRenderData 数组（用于旧版兼容性）。
      *
-     * Sprites are returned in insertion order to preserve z-ordering.
-     * The rendering system is responsible for sorting sprites before adding them.
-     * 精灵按插入顺序返回以保持 z 顺序。
-     * 渲染系统负责在添加精灵前对其进行排序。
+     * Uses object pool to avoid allocations.
+     * 使用对象池以避免分配。
      *
-     * @returns Array of sprites in insertion order | 按插入顺序排列的精灵数组
+     * @returns Array of sprites from pool | 来自池的精灵数组
      */
     getSprites(): SpriteRenderData[] {
-        // NOTE: Previously sorted by materialId/textureId for batching optimization,
-        // but this broke z-ordering for UI elements where render order is critical.
-        // Sprites should be added in the correct render order by the caller.
-        // 注意：之前按 materialId/textureId 排序以优化批处理，
-        // 但这破坏了 UI 元素的 z 排序，而 UI 的渲染顺序至关重要。
-        // 调用者应该以正确的渲染顺序添加精灵。
-        return this.sprites;
+        // Reset pool index to reuse objects | 重置池索引以复用对象
+        this._poolIndex = 0;
+
+        const result: SpriteRenderData[] = [];
+        for (let i = 0; i < this._count; i++) {
+            const sprite = this._getFromPool();
+            const tOffset = i * 7;
+            const uvOffset = i * 4;
+
+            // Fill from SoA buffers | 从 SoA 缓冲区填充
+            sprite.x = this._transforms[tOffset];
+            sprite.y = this._transforms[tOffset + 1];
+            sprite.rotation = this._transforms[tOffset + 2];
+            sprite.scaleX = this._transforms[tOffset + 3];
+            sprite.scaleY = this._transforms[tOffset + 4];
+            sprite.originX = this._transforms[tOffset + 5];
+            sprite.originY = this._transforms[tOffset + 6];
+
+            sprite.textureId = this._textureIds[i];
+
+            sprite.uv[0] = this._uvs[uvOffset];
+            sprite.uv[1] = this._uvs[uvOffset + 1];
+            sprite.uv[2] = this._uvs[uvOffset + 2];
+            sprite.uv[3] = this._uvs[uvOffset + 3];
+
+            sprite.color = this._colors[i];
+            sprite.materialId = this._materialIds[i];
+
+            // Attach optional data | 附加可选数据
+            sprite.materialOverrides = this._materialOverrides.get(i);
+            sprite.clipRect = this._clipRects.get(i);
+
+            result.push(sprite);
+        }
+
+        return result;
     }
+
+    // ===== State =====
+    // ===== 状态 =====
 
     /**
      * Get sprite count.
      * 获取精灵数量。
      */
     get count(): number {
-        return this.sprites.length;
+        return this._count;
     }
 
     /**
-     * Clear all sprites from the batch.
-     * 清除批处理中的所有精灵。
+     * Get capacity.
+     * 获取容量。
      */
-    clear(): void {
-        this.sprites.length = 0;
+    get capacity(): number {
+        return this._capacity;
     }
 
     /**
@@ -108,6 +388,52 @@ export class RenderBatcher {
      * 检查批处理是否为空。
      */
     get isEmpty(): boolean {
-        return this.sprites.length === 0;
+        return this._count === 0;
+    }
+
+    /**
+     * Clear all sprites from the batch.
+     * 清除批处理中的所有精灵。
+     *
+     * Does NOT deallocate buffers - they are reused next frame.
+     * 不会释放缓冲区 - 它们在下一帧被复用。
+     */
+    clear(): void {
+        this._count = 0;
+        this._poolIndex = 0;
+        this._materialOverrides.clear();
+        this._clipRects.clear();
+    }
+
+    /**
+     * Check if material overrides exist for any sprite.
+     * 检查是否有任何精灵存在材质覆盖。
+     */
+    hasMaterialOverrides(): boolean {
+        return this._materialOverrides.size > 0;
+    }
+
+    /**
+     * Get material overrides for a sprite index.
+     * 获取精灵索引的材质覆盖。
+     */
+    getMaterialOverrides(index: number): MaterialOverrides | undefined {
+        return this._materialOverrides.get(index);
+    }
+
+    /**
+     * Check if clip rects exist for any sprite.
+     * 检查是否有任何精灵存在裁剪矩形。
+     */
+    hasClipRects(): boolean {
+        return this._clipRects.size > 0;
+    }
+
+    /**
+     * Get clip rect for a sprite index.
+     * 获取精灵索引的裁剪矩形。
+     */
+    getClipRect(index: number): { x: number; y: number; width: number; height: number } | undefined {
+        return this._clipRects.get(index);
     }
 }

--- a/packages/ecs-engine-bindgen/src/core/SpriteRenderHelper.ts
+++ b/packages/ecs-engine-bindgen/src/core/SpriteRenderHelper.ts
@@ -143,7 +143,11 @@ export class SpriteRenderHelper {
      */
     render(): void {
         if (!this.batcher.isEmpty) {
-            this.bridge.submitSprites(this.batcher.getSprites());
+            const buffers = this.batcher.getBuffers();
+            this.bridge.submitSprites(
+                buffers.transforms, buffers.textureIds, buffers.uvs,
+                buffers.colors, buffers.materialIds, buffers.count
+            );
         }
         this.bridge.render();
     }

--- a/packages/engine-core/src/TransformComponent.ts
+++ b/packages/engine-core/src/TransformComponent.ts
@@ -17,21 +17,121 @@ export interface Matrix2D {
     ty: number;  // translateY
 }
 
+/**
+ * Reactive Vector3 that automatically sets dirty flag on parent transform.
+ * 响应式 Vector3，在修改时自动设置父变换的脏标记。
+ *
+ * @internal
+ */
+class ReactiveVector3 implements IVector3 {
+    private _x: number;
+    private _y: number;
+    private _z: number;
+    private _owner: TransformComponent;
+
+    constructor(owner: TransformComponent, x: number = 0, y: number = 0, z: number = 0) {
+        this._owner = owner;
+        this._x = x;
+        this._y = y;
+        this._z = z;
+    }
+
+    get x(): number { return this._x; }
+    set x(value: number) {
+        if (this._x !== value) {
+            this._x = value;
+            this._owner.markDirty();
+        }
+    }
+
+    get y(): number { return this._y; }
+    set y(value: number) {
+        if (this._y !== value) {
+            this._y = value;
+            this._owner.markDirty();
+        }
+    }
+
+    get z(): number { return this._z; }
+    set z(value: number) {
+        if (this._z !== value) {
+            this._z = value;
+            this._owner.markDirty();
+        }
+    }
+
+    /**
+     * Set all components at once (more efficient than setting individually).
+     * 一次性设置所有分量（比单独设置更高效）。
+     */
+    set(x: number, y: number, z: number = this._z): void {
+        const changed = this._x !== x || this._y !== y || this._z !== z;
+        this._x = x;
+        this._y = y;
+        this._z = z;
+        if (changed) {
+            this._owner.markDirty();
+        }
+    }
+
+    /**
+     * Copy from another vector.
+     * 从另一个向量复制。
+     */
+    copyFrom(v: IVector3): void {
+        this.set(v.x, v.y, v.z);
+    }
+
+    /**
+     * Get raw values without triggering getters (for serialization).
+     * 获取原始值而不触发 getter（用于序列化）。
+     */
+    toObject(): IVector3 {
+        return { x: this._x, y: this._y, z: this._z };
+    }
+}
+
 @ECSComponent('Transform')
 @Serializable({ version: 1, typeId: 'Transform' })
 export class TransformComponent extends Component {
+    // ===== 内部响应式存储 =====
+    private _position: ReactiveVector3;
+    private _rotation: ReactiveVector3;
+    private _scale: ReactiveVector3;
+
     @Serialize()
     @Property({ type: 'vector3', label: 'Position' })
-    position: IVector3 = { x: 0, y: 0, z: 0 };
+    get position(): IVector3 { return this._position; }
+    set position(value: IVector3) {
+        if (this._position) {
+            this._position.copyFrom(value);
+        } else {
+            this._position = new ReactiveVector3(this, value.x, value.y, value.z);
+        }
+    }
 
-    /** 欧拉角，单位：度 */
+    /** 欧拉角，单位：度 | Euler angles in degrees */
     @Serialize()
     @Property({ type: 'vector3', label: 'Rotation' })
-    rotation: IVector3 = { x: 0, y: 0, z: 0 };
+    get rotation(): IVector3 { return this._rotation; }
+    set rotation(value: IVector3) {
+        if (this._rotation) {
+            this._rotation.copyFrom(value);
+        } else {
+            this._rotation = new ReactiveVector3(this, value.x, value.y, value.z);
+        }
+    }
 
     @Serialize()
     @Property({ type: 'vector3', label: 'Scale' })
-    scale: IVector3 = { x: 1, y: 1, z: 1 };
+    get scale(): IVector3 { return this._scale; }
+    set scale(value: IVector3) {
+        if (this._scale) {
+            this._scale.copyFrom(value);
+        } else {
+            this._scale = new ReactiveVector3(this, value.x, value.y, value.z);
+        }
+    }
 
     // ===== 世界变换（由 TransformSystem 计算）=====
 
@@ -47,31 +147,64 @@ export class TransformComponent extends Component {
     /** 本地到世界的 2D 变换矩阵（只读，由 TransformSystem 计算） */
     localToWorldMatrix: Matrix2D = { a: 1, b: 0, c: 0, d: 1, tx: 0, ty: 0 };
 
-    /** 变换是否需要更新 */
+    /** 变换是否需要更新 | Whether transform needs update */
     bDirty: boolean = true;
+
+    /**
+     * Frame counter when last updated (for change detection).
+     * 上次更新的帧计数器（用于变化检测）。
+     * @internal
+     */
+    _lastUpdateFrame: number = -1;
+
+    /**
+     * Cached render data version (incremented when transform changes).
+     * 缓存的渲染数据版本（变换改变时递增）。
+     * @internal
+     */
+    _version: number = 0;
 
     constructor(x: number = 0, y: number = 0, z: number = 0) {
         super();
-        this.position = { x, y, z };
+        this._position = new ReactiveVector3(this, x, y, z);
+        this._rotation = new ReactiveVector3(this, 0, 0, 0);
+        this._scale = new ReactiveVector3(this, 1, 1, 1);
         // 初始化世界变换为本地变换值（在 TransformSystem 更新前使用）
         this.worldPosition = { x, y, z };
     }
 
+    /**
+     * Mark transform as dirty and increment version.
+     * 标记变换为脏并递增版本号。
+     */
+    markDirty(): void {
+        if (!this.bDirty) {
+            this.bDirty = true;
+            this._version++;
+        }
+    }
+
+    /**
+     * Clear dirty flag (called by TransformSystem after update).
+     * 清除脏标记（由 TransformSystem 更新后调用）。
+     */
+    clearDirty(frameNumber: number): void {
+        this.bDirty = false;
+        this._lastUpdateFrame = frameNumber;
+    }
+
     setPosition(x: number, y: number, z: number = 0): this {
-        this.position = { x, y, z };
-        this.bDirty = true;
+        this._position.set(x, y, z);
         return this;
     }
 
     setRotation(x: number, y: number, z: number): this {
-        this.rotation = { x, y, z };
-        this.bDirty = true;
+        this._rotation.set(x, y, z);
         return this;
     }
 
     setScale(x: number, y: number, z: number = 1): this {
-        this.scale = { x, y, z };
-        this.bDirty = true;
+        this._scale.set(x, y, z);
         return this;
     }
 


### PR DESCRIPTION
## Summary
- 将 `submitSpritesDirectly` 重命名为 `submitSprites`，移除旧的对象数组 API
- RenderBatcher 采用 SoA 模式，预分配类型数组避免每帧 GC
- 拆分 `worldBatcher` 和 `screenBatcher` 修复 play 模式下的双重渲染
- 移除未使用的材质实例管理代码

## Test plan
- [ ] 编辑器正常渲染场景
- [ ] Play 模式下不再出现双重渲染
- [ ] UI 在 preview 模式下正确显示在屏幕空间