### PR TITLE
ci: 集成 Turborepo Remote Cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
 
     steps:
     - name: Checkout code
@@ -67,17 +70,7 @@ jobs:
     - name: Install dependencies
       run: pnpm install --no-frozen-lockfile
 
-    # 缓存 Turbo
-    - name: Cache Turbo
-      uses: actions/cache@v4
-      with:
-        path: .turbo
-        key: turbo-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ github.sha }}
-        restore-keys: |
-          turbo-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}-
-          turbo-${{ runner.os }}-
-
-    # 构建所有包
+    # 构建所有包 (使用 Turborepo Remote Cache)
     - name: Build all packages
       run: pnpm run build
 


### PR DESCRIPTION
## Summary
- 集成 Vercel Turborepo Remote Cache，加速 CI 构建
- 移除本地 .turbo 缓存（remote cache 更高效）

## 效果
- 首次构建：正常时间
- 后续构建：未修改的包直接从云端缓存拉取，秒级完成

## 配置
需要在 GitHub Secrets 中配置：
- `TURBO_TOKEN`: Vercel API Token
- `TURBO_TEAM`: Vercel 团队名