### PR TITLE
refactor(blueprint): 使用 ecs-framework 的 Entity 和 IScene 类型

### DIFF
--- a/packages/blueprint/src/runtime/BlueprintComponent.ts
+++ b/packages/blueprint/src/runtime/BlueprintComponent.ts
@@ -3,9 +3,9 @@
  * 蓝图组件 - 将蓝图附加到实体
  */
 
+import type { Entity, IScene } from '@esengine/ecs-framework';
 import { BlueprintAsset } from '../types/blueprint';
 import { BlueprintVM } from './BlueprintVM';
-import { IEntity, IScene } from './ExecutionContext';
 
 /**
  * Component interface for ECS integration
@@ -56,7 +56,7 @@ export function createBlueprintComponentData(): IBlueprintComponent {
  */
 export function initializeBlueprintVM(
     component: IBlueprintComponent,
-    entity: IEntity,
+    entity: Entity,
     scene: IScene
 ): void {
     if (!component.blueprintAsset) {

--- a/packages/blueprint/src/runtime/BlueprintSystem.ts
+++ b/packages/blueprint/src/runtime/BlueprintSystem.ts
@@ -3,6 +3,7 @@
  * 蓝图执行系统 - 管理蓝图生命周期和执行
  */
 
+import type { Entity, IScene } from '@esengine/ecs-framework';
 import {
     IBlueprintComponent,
     initializeBlueprintVM,
@@ -10,7 +11,6 @@ import {
     tickBlueprint,
     cleanupBlueprint
 } from './BlueprintComponent';
-import { IEntity, IScene } from './ExecutionContext';
 
 /**
  * Blueprint system interface for engine integration
@@ -31,7 +31,7 @@ export interface IBlueprintSystem {
  * Entity with blueprint component
  * 带有蓝图组件的实体
  */
-export interface IBlueprintEntity extends IEntity {
+export interface IBlueprintEntity extends Entity {
     /** Blueprint component data (蓝图组件数据) */
     blueprintComponent: IBlueprintComponent;
 }

--- a/packages/blueprint/src/runtime/BlueprintVM.ts
+++ b/packages/blueprint/src/runtime/BlueprintVM.ts
@@ -3,9 +3,10 @@
  * 蓝图虚拟机 - 执行蓝图图
  */
 
+import type { Entity, IScene } from '@esengine/ecs-framework';
 import { BlueprintNode } from '../types/nodes';
 import { BlueprintAsset } from '../types/blueprint';
-import { ExecutionContext, ExecutionResult, IEntity, IScene } from './ExecutionContext';
+import { ExecutionContext, ExecutionResult } from './ExecutionContext';
 import { NodeRegistry } from './NodeRegistry';
 
 /**
@@ -57,7 +58,7 @@ export class BlueprintVM {
     /** Debug mode (调试模式) */
     debug: boolean = false;
 
-    constructor(blueprint: BlueprintAsset, entity: IEntity, scene: IScene) {
+    constructor(blueprint: BlueprintAsset, entity: Entity, scene: IScene) {
         this._context = new ExecutionContext(blueprint, entity, scene);
         this._cacheEventNodes();
     }

--- a/packages/blueprint/src/runtime/ExecutionContext.ts
+++ b/packages/blueprint/src/runtime/ExecutionContext.ts
@@ -3,6 +3,7 @@
  * 执行上下文 - 蓝图执行的运行时上下文
  */
 
+import type { Entity, IScene } from '@esengine/ecs-framework';
 import { BlueprintNode, BlueprintConnection } from '../types/nodes';
 import { BlueprintAsset } from '../types/blueprint';
 
@@ -43,31 +44,6 @@ export interface ExecutionResult {
 }
 
 /**
- * Entity interface (minimal for decoupling)
- * 实体接口（最小化以解耦）
- */
-export interface IEntity {
-    id: number;
-    name: string;
-    active: boolean;
-    getComponent<T>(type: new (...args: unknown[]) => T): T | null;
-    addComponent<T>(component: T): T;
-    removeComponent<T>(type: new (...args: unknown[]) => T): void;
-    hasComponent<T>(type: new (...args: unknown[]) => T): boolean;
-}
-
-/**
- * Scene interface (minimal for decoupling)
- * 场景接口（最小化以解耦）
- */
-export interface IScene {
-    createEntity(name?: string): IEntity;
-    destroyEntity(entity: IEntity): void;
-    findEntityByName(name: string): IEntity | null;
-    findEntitiesByTag(tag: number): IEntity[];
-}
-
-/**
  * Execution context provides access to runtime services
  * 执行上下文提供对运行时服务的访问
  */
@@ -76,7 +52,7 @@ export class ExecutionContext {
     readonly blueprint: BlueprintAsset;
 
     /** Owner entity (所有者实体) */
-    readonly entity: IEntity;
+    readonly entity: Entity;
 
     /** Current scene (当前场景) */
     readonly scene: IScene;
@@ -105,7 +81,7 @@ export class ExecutionContext {
     /** Connection lookup by source (按源的连接查找) */
     private _connectionsBySource: Map<string, BlueprintConnection[]> = new Map();
 
-    constructor(blueprint: BlueprintAsset, entity: IEntity, scene: IScene) {
+    constructor(blueprint: BlueprintAsset, entity: Entity, scene: IScene) {
         this.blueprint = blueprint;
         this.entity = entity;
         this.scene = scene;


### PR DESCRIPTION
## Summary

- 从 `@esengine/ecs-framework` 导入 `Entity` 和 `IScene` 类型
- 移除 `ExecutionContext.ts` 中的自定义 `IEntity` 和 `IScene` 接口
- 更新 `BlueprintComponent.ts`、`BlueprintVM.ts`、`BlueprintSystem.ts` 使用正确的类型

这使得 blueprint 包与 ecs-framework 的类型保持一致，避免重复定义接口。

## Test plan

- [x] `pnpm --filter @esengine/blueprint type-check` 通过
- [x] `pnpm --filter @esengine/blueprint build` 通过