### PR TITLE
fix: 修复 changesets 验证错误

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -13,12 +13,6 @@
   "baseBranch": "master",
   "updateInternalDependencies": "patch",
   "ignore": [
-    "@esengine/editor-app",
-    "@esengine/editor-core",
-    "@esengine/editor-runtime",
-    "@esengine/*-editor",
-    "@esengine/engine",
-    "@esengine/build-config",
-    "@esengine/ecs-engine-bindgen"
+    "@esengine/editor-app"
   ]
 }

--- a/packages/asset-system-editor/package.json
+++ b/packages/asset-system-editor/package.json
@@ -46,5 +46,6 @@
     "type": "git",
     "url": "https://github.com/esengine/esengine.git",
     "directory": "packages/asset-system-editor"
-  }
+  },
+  "private": true
 }

--- a/packages/behavior-tree-editor/package.json
+++ b/packages/behavior-tree-editor/package.json
@@ -1,52 +1,53 @@
 {
-    "name": "@esengine/behavior-tree-editor",
-    "version": "1.0.0",
-    "description": "Editor support for @esengine/behavior-tree - visual editor, inspectors, and tools",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "type": "module",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "import": "./dist/index.js"
-        }
-    },
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsup",
-        "build:watch": "tsup --watch",
-        "type-check": "tsc --noEmit",
-        "clean": "rimraf dist"
-    },
-    "dependencies": {
-        "@esengine/behavior-tree": "workspace:*"
-    },
-    "peerDependencies": {
-        "@esengine/editor-core": "workspace:*"
-    },
-    "devDependencies": {
-        "@esengine/ecs-framework": "workspace:*",
-        "@esengine/engine-core": "workspace:*",
-        "@esengine/editor-core": "workspace:*",
-        "@esengine/editor-runtime": "workspace:*",
-        "@esengine/node-editor": "workspace:*",
-        "@esengine/build-config": "workspace:*",
-        "lucide-react": "^0.545.0",
-        "react": "^18.3.1",
-        "zustand": "^5.0.8",
-        "@types/react": "^18.3.12",
-        "rimraf": "^5.0.5",
-        "tsup": "^8.0.0",
-        "typescript": "^5.3.3"
-    },
-    "keywords": [
-        "ecs",
-        "behavior-tree",
-        "editor"
-    ],
-    "author": "",
-    "license": "MIT"
+  "name": "@esengine/behavior-tree-editor",
+  "version": "1.0.0",
+  "description": "Editor support for @esengine/behavior-tree - visual editor, inspectors, and tools",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "build:watch": "tsup --watch",
+    "type-check": "tsc --noEmit",
+    "clean": "rimraf dist"
+  },
+  "dependencies": {
+    "@esengine/behavior-tree": "workspace:*"
+  },
+  "peerDependencies": {
+    "@esengine/editor-core": "workspace:*"
+  },
+  "devDependencies": {
+    "@esengine/ecs-framework": "workspace:*",
+    "@esengine/engine-core": "workspace:*",
+    "@esengine/editor-core": "workspace:*",
+    "@esengine/editor-runtime": "workspace:*",
+    "@esengine/node-editor": "workspace:*",
+    "@esengine/build-config": "workspace:*",
+    "lucide-react": "^0.545.0",
+    "react": "^18.3.1",
+    "zustand": "^5.0.8",
+    "@types/react": "^18.3.12",
+    "rimraf": "^5.0.5",
+    "tsup": "^8.0.0",
+    "typescript": "^5.3.3"
+  },
+  "keywords": [
+    "ecs",
+    "behavior-tree",
+    "editor"
+  ],
+  "author": "",
+  "license": "MIT",
+  "private": true
 }

--- a/packages/blueprint-editor/package.json
+++ b/packages/blueprint-editor/package.json
@@ -1,52 +1,53 @@
 {
-    "name": "@esengine/blueprint-editor",
-    "version": "1.0.0",
-    "description": "Editor support for @esengine/blueprint - visual scripting editor",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "type": "module",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "import": "./dist/index.js"
-        }
-    },
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsup",
-        "build:watch": "tsup --watch",
-        "type-check": "tsc --noEmit",
-        "clean": "rimraf dist"
-    },
-    "dependencies": {
-        "@esengine/blueprint": "workspace:*"
-    },
-    "peerDependencies": {
-        "@esengine/editor-core": "workspace:*"
-    },
-    "devDependencies": {
-        "@esengine/ecs-framework": "workspace:*",
-        "@esengine/engine-core": "workspace:*",
-        "@esengine/editor-core": "workspace:*",
-        "@esengine/node-editor": "workspace:*",
-        "@esengine/build-config": "workspace:*",
-        "lucide-react": "^0.545.0",
-        "react": "^18.3.1",
-        "zustand": "^5.0.8",
-        "@types/react": "^18.3.12",
-        "rimraf": "^5.0.5",
-        "tsup": "^8.0.0",
-        "typescript": "^5.3.3"
-    },
-    "keywords": [
-        "ecs",
-        "blueprint",
-        "editor",
-        "visual-scripting"
-    ],
-    "author": "",
-    "license": "MIT"
+  "name": "@esengine/blueprint-editor",
+  "version": "1.0.0",
+  "description": "Editor support for @esengine/blueprint - visual scripting editor",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "build:watch": "tsup --watch",
+    "type-check": "tsc --noEmit",
+    "clean": "rimraf dist"
+  },
+  "dependencies": {
+    "@esengine/blueprint": "workspace:*"
+  },
+  "peerDependencies": {
+    "@esengine/editor-core": "workspace:*"
+  },
+  "devDependencies": {
+    "@esengine/ecs-framework": "workspace:*",
+    "@esengine/engine-core": "workspace:*",
+    "@esengine/editor-core": "workspace:*",
+    "@esengine/node-editor": "workspace:*",
+    "@esengine/build-config": "workspace:*",
+    "lucide-react": "^0.545.0",
+    "react": "^18.3.1",
+    "zustand": "^5.0.8",
+    "@types/react": "^18.3.12",
+    "rimraf": "^5.0.5",
+    "tsup": "^8.0.0",
+    "typescript": "^5.3.3"
+  },
+  "keywords": [
+    "ecs",
+    "blueprint",
+    "editor",
+    "visual-scripting"
+  ],
+  "author": "",
+  "license": "MIT",
+  "private": true
 }

--- a/packages/build-config/package.json
+++ b/packages/build-config/package.json
@@ -1,39 +1,40 @@
 {
-    "name": "@esengine/build-config",
-    "version": "1.0.0",
-    "description": "Shared build configuration for ES Engine packages",
-    "type": "module",
-    "main": "src/index.ts",
-    "exports": {
-        ".": "./src/index.ts",
-        "./presets": "./src/presets/index.ts",
-        "./presets/tsup": "./src/presets/plugin-tsup.ts",
-        "./plugins": "./src/plugins/index.ts"
-    },
-    "scripts": {
-        "type-check": "tsc --noEmit"
-    },
-    "keywords": [
-        "build",
-        "tsup",
-        "config"
-    ],
-    "author": "yhh",
-    "license": "MIT",
-    "devDependencies": {
-        "@vitejs/plugin-react": "^4.3.4",
-        "tsup": "^8.0.0",
-        "typescript": "^5.8.3",
-        "vite": "^6.3.5",
-        "vite-plugin-dts": "^4.5.4"
-    },
-    "peerDependencies": {
-        "tsup": "^8.0.0",
-        "vite": "^6.0.0"
-    },
-    "peerDependenciesMeta": {
-        "vite": {
-            "optional": true
-        }
+  "name": "@esengine/build-config",
+  "version": "1.0.0",
+  "description": "Shared build configuration for ES Engine packages",
+  "type": "module",
+  "main": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./presets": "./src/presets/index.ts",
+    "./presets/tsup": "./src/presets/plugin-tsup.ts",
+    "./plugins": "./src/plugins/index.ts"
+  },
+  "scripts": {
+    "type-check": "tsc --noEmit"
+  },
+  "keywords": [
+    "build",
+    "tsup",
+    "config"
+  ],
+  "author": "yhh",
+  "license": "MIT",
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.3.4",
+    "tsup": "^8.0.0",
+    "typescript": "^5.8.3",
+    "vite": "^6.3.5",
+    "vite-plugin-dts": "^4.5.4"
+  },
+  "peerDependencies": {
+    "tsup": "^8.0.0",
+    "vite": "^6.0.0"
+  },
+  "peerDependenciesMeta": {
+    "vite": {
+      "optional": true
     }
+  },
+  "private": true
 }

--- a/packages/camera-editor/package.json
+++ b/packages/camera-editor/package.json
@@ -1,48 +1,49 @@
 {
-    "name": "@esengine/camera-editor",
-    "version": "1.0.0",
-    "description": "Editor components for camera system",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "type": "module",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "import": "./dist/index.js"
-        }
-    },
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsup",
-        "build:watch": "tsup --watch",
-        "type-check": "tsc --noEmit",
-        "clean": "rimraf dist"
-    },
-    "dependencies": {
-        "@esengine/camera": "workspace:*"
-    },
-    "peerDependencies": {
-        "@esengine/editor-core": "workspace:*"
-    },
-    "devDependencies": {
-        "@esengine/ecs-framework": "workspace:*",
-        "@esengine/engine-core": "workspace:*",
-        "@esengine/editor-core": "workspace:*",
-        "@esengine/build-config": "workspace:*",
-        "react": "^18.3.1",
-        "@types/react": "^18.2.0",
-        "rimraf": "^5.0.5",
-        "tsup": "^8.0.0",
-        "typescript": "^5.3.3"
-    },
-    "keywords": [
-        "ecs",
-        "camera",
-        "editor"
-    ],
-    "author": "yhh",
-    "license": "MIT"
+  "name": "@esengine/camera-editor",
+  "version": "1.0.0",
+  "description": "Editor components for camera system",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "build:watch": "tsup --watch",
+    "type-check": "tsc --noEmit",
+    "clean": "rimraf dist"
+  },
+  "dependencies": {
+    "@esengine/camera": "workspace:*"
+  },
+  "peerDependencies": {
+    "@esengine/editor-core": "workspace:*"
+  },
+  "devDependencies": {
+    "@esengine/ecs-framework": "workspace:*",
+    "@esengine/engine-core": "workspace:*",
+    "@esengine/editor-core": "workspace:*",
+    "@esengine/build-config": "workspace:*",
+    "react": "^18.3.1",
+    "@types/react": "^18.2.0",
+    "rimraf": "^5.0.5",
+    "tsup": "^8.0.0",
+    "typescript": "^5.3.3"
+  },
+  "keywords": [
+    "ecs",
+    "camera",
+    "editor"
+  ],
+  "author": "yhh",
+  "license": "MIT",
+  "private": true
 }

--- a/packages/ecs-engine-bindgen/package.json
+++ b/packages/ecs-engine-bindgen/package.json
@@ -1,62 +1,67 @@
 {
-    "name": "@esengine/ecs-engine-bindgen",
-    "version": "0.1.0",
-    "description": "Bridge layer between ECS Framework and Rust Engine | ECS框架与Rust引擎之间的桥接层",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "type": "module",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "import": "./dist/index.js"
-        }
-    },
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsup",
-        "build:watch": "tsup --watch",
-        "clean": "rimraf dist"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/esengine/esengine.git",
-        "directory": "packages/ecs-engine-bindgen"
-    },
-    "keywords": [
-        "ecs",
-        "game-engine",
-        "bridge",
-        "wasm",
-        "typescript"
-    ],
-    "author": "ESEngine Team",
-    "license": "MIT",
-    "dependencies": {
-        "@esengine/ecs-framework": "workspace:*",
-        "@esengine/ecs-framework-math": "workspace:*",
-        "@esengine/engine-core": "workspace:*",
-        "@esengine/asset-system": "workspace:*",
-        "@esengine/material-system": "workspace:*"
-    },
-    "peerDependencies": {
-        "@esengine/sprite": "workspace:*",
-        "@esengine/camera": "workspace:*"
-    },
-    "peerDependenciesMeta": {
-        "@esengine/sprite": { "optional": true },
-        "@esengine/camera": { "optional": true }
-    },
-    "optionalDependencies": {
-        "es-engine": "file:../engine/pkg"
-    },
-    "devDependencies": {
-        "@esengine/sprite": "workspace:*",
-        "@esengine/camera": "workspace:*",
-        "tsup": "^8.5.1",
-        "typescript": "^5.8.0",
-        "rimraf": "^5.0.0"
+  "name": "@esengine/ecs-engine-bindgen",
+  "version": "0.1.0",
+  "description": "Bridge layer between ECS Framework and Rust Engine | ECS框架与Rust引擎之间的桥接层",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
     }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "build:watch": "tsup --watch",
+    "clean": "rimraf dist"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/esengine/esengine.git",
+    "directory": "packages/ecs-engine-bindgen"
+  },
+  "keywords": [
+    "ecs",
+    "game-engine",
+    "bridge",
+    "wasm",
+    "typescript"
+  ],
+  "author": "ESEngine Team",
+  "license": "MIT",
+  "dependencies": {
+    "@esengine/ecs-framework": "workspace:*",
+    "@esengine/ecs-framework-math": "workspace:*",
+    "@esengine/engine-core": "workspace:*",
+    "@esengine/asset-system": "workspace:*",
+    "@esengine/material-system": "workspace:*"
+  },
+  "peerDependencies": {
+    "@esengine/sprite": "workspace:*",
+    "@esengine/camera": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@esengine/sprite": {
+      "optional": true
+    },
+    "@esengine/camera": {
+      "optional": true
+    }
+  },
+  "optionalDependencies": {
+    "es-engine": "file:../engine/pkg"
+  },
+  "devDependencies": {
+    "@esengine/sprite": "workspace:*",
+    "@esengine/camera": "workspace:*",
+    "tsup": "^8.5.1",
+    "typescript": "^5.8.0",
+    "rimraf": "^5.0.0"
+  },
+  "private": true
 }

--- a/packages/editor-core/package.json
+++ b/packages/editor-core/package.json
@@ -76,5 +76,6 @@
     "type": "git",
     "url": "https://github.com/esengine/esengine.git",
     "directory": "packages/editor-core"
-  }
+  },
+  "private": true
 }

--- a/packages/editor-runtime/package.json
+++ b/packages/editor-runtime/package.json
@@ -43,5 +43,6 @@
     "typescript": "^5.8.3",
     "vite": "^6.0.7",
     "vite-plugin-dts": "^4.5.0"
-  }
+  },
+  "private": true
 }

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,48 +1,49 @@
 {
-    "name": "@esengine/engine",
-    "version": "0.1.0",
-    "description": "High-performance 2D game engine built with Rust and WebAssembly | 使用Rust和WebAssembly构建的高性能2D游戏引擎",
-    "main": "pkg/es_engine.js",
-    "types": "pkg/es_engine.d.ts",
-    "exports": {
-        ".": {
-            "import": "./pkg/es_engine.js",
-            "types": "./pkg/es_engine.d.ts"
-        },
-        "./wasm": {
-            "default": "./pkg/es_engine_bg.wasm"
-        }
+  "name": "@esengine/engine",
+  "version": "0.1.0",
+  "description": "High-performance 2D game engine built with Rust and WebAssembly | 使用Rust和WebAssembly构建的高性能2D游戏引擎",
+  "main": "pkg/es_engine.js",
+  "types": "pkg/es_engine.d.ts",
+  "exports": {
+    ".": {
+      "import": "./pkg/es_engine.js",
+      "types": "./pkg/es_engine.d.ts"
     },
-    "unpkg": "pkg/es_engine.js",
-    "jsdelivr": "pkg/es_engine.js",
-    "files": [
-        "pkg"
-    ],
-    "scripts": {
-        "build": "wasm-pack build --target web --out-dir pkg",
-        "build:release": "wasm-pack build --target web --out-dir pkg --release",
-        "build:bundler": "wasm-pack build --target bundler --out-dir pkg",
-        "clean": "rimraf pkg target",
-        "test": "wasm-pack test --headless --firefox"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/esengine/esengine.git",
-        "directory": "packages/engine"
-    },
-    "keywords": [
-        "game-engine",
-        "2d",
-        "webgl",
-        "wasm",
-        "rust",
-        "ecs",
-        "webassembly"
-    ],
-    "author": "ESEngine Team",
-    "license": "MIT",
-    "devDependencies": {
-        "rimraf": "^5.0.0"
-    },
-    "peerDependencies": {}
+    "./wasm": {
+      "default": "./pkg/es_engine_bg.wasm"
+    }
+  },
+  "unpkg": "pkg/es_engine.js",
+  "jsdelivr": "pkg/es_engine.js",
+  "files": [
+    "pkg"
+  ],
+  "scripts": {
+    "build": "wasm-pack build --target web --out-dir pkg",
+    "build:release": "wasm-pack build --target web --out-dir pkg --release",
+    "build:bundler": "wasm-pack build --target bundler --out-dir pkg",
+    "clean": "rimraf pkg target",
+    "test": "wasm-pack test --headless --firefox"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/esengine/esengine.git",
+    "directory": "packages/engine"
+  },
+  "keywords": [
+    "game-engine",
+    "2d",
+    "webgl",
+    "wasm",
+    "rust",
+    "ecs",
+    "webassembly"
+  ],
+  "author": "ESEngine Team",
+  "license": "MIT",
+  "devDependencies": {
+    "rimraf": "^5.0.0"
+  },
+  "peerDependencies": {},
+  "private": true
 }

--- a/packages/fairygui-editor/package.json
+++ b/packages/fairygui-editor/package.json
@@ -1,52 +1,53 @@
 {
-    "name": "@esengine/fairygui-editor",
-    "version": "1.0.0",
-    "description": "Editor support for @esengine/fairygui - inspectors, gizmos, and entity templates",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "type": "module",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "import": "./dist/index.js"
-        },
-        "./plugin.json": "./plugin.json"
+  "name": "@esengine/fairygui-editor",
+  "version": "1.0.0",
+  "description": "Editor support for @esengine/fairygui - inspectors, gizmos, and entity templates",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
     },
-    "files": [
-        "dist",
-        "plugin.json"
-    ],
-    "scripts": {
-        "build": "tsup",
-        "build:watch": "tsup --watch",
-        "type-check": "tsc --noEmit",
-        "clean": "rimraf dist"
-    },
-    "dependencies": {
-        "@esengine/fairygui": "workspace:*"
-    },
-    "peerDependencies": {
-        "@esengine/editor-core": "workspace:*"
-    },
-    "devDependencies": {
-        "@esengine/ecs-framework": "workspace:*",
-        "@esengine/engine-core": "workspace:*",
-        "@esengine/editor-core": "workspace:*",
-        "@esengine/asset-system": "workspace:*",
-        "@esengine/build-config": "workspace:*",
-        "lucide-react": "^0.545.0",
-        "react": "^18.3.1",
-        "@types/react": "^18.3.12",
-        "rimraf": "^5.0.5",
-        "tsup": "^8.0.0",
-        "typescript": "^5.3.3"
-    },
-    "keywords": [
-        "ecs",
-        "fairygui",
-        "editor"
-    ],
-    "author": "",
-    "license": "MIT"
+    "./plugin.json": "./plugin.json"
+  },
+  "files": [
+    "dist",
+    "plugin.json"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "build:watch": "tsup --watch",
+    "type-check": "tsc --noEmit",
+    "clean": "rimraf dist"
+  },
+  "dependencies": {
+    "@esengine/fairygui": "workspace:*"
+  },
+  "peerDependencies": {
+    "@esengine/editor-core": "workspace:*"
+  },
+  "devDependencies": {
+    "@esengine/ecs-framework": "workspace:*",
+    "@esengine/engine-core": "workspace:*",
+    "@esengine/editor-core": "workspace:*",
+    "@esengine/asset-system": "workspace:*",
+    "@esengine/build-config": "workspace:*",
+    "lucide-react": "^0.545.0",
+    "react": "^18.3.1",
+    "@types/react": "^18.3.12",
+    "rimraf": "^5.0.5",
+    "tsup": "^8.0.0",
+    "typescript": "^5.3.3"
+  },
+  "keywords": [
+    "ecs",
+    "fairygui",
+    "editor"
+  ],
+  "author": "",
+  "license": "MIT",
+  "private": true
 }

--- a/packages/material-editor/package.json
+++ b/packages/material-editor/package.json
@@ -1,51 +1,52 @@
 {
-    "name": "@esengine/material-editor",
-    "version": "1.0.0",
-    "description": "Editor components for material system",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "type": "module",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "import": "./dist/index.js"
-        }
-    },
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsup",
-        "build:watch": "tsup --watch",
-        "type-check": "tsc --noEmit",
-        "clean": "rimraf dist"
-    },
-    "dependencies": {
-        "@esengine/material-system": "workspace:*"
-    },
-    "peerDependencies": {
-        "@esengine/editor-core": "workspace:*"
-    },
-    "devDependencies": {
-        "@esengine/ecs-framework": "workspace:*",
-        "@esengine/engine-core": "workspace:*",
-        "@esengine/editor-core": "workspace:*",
-        "@esengine/build-config": "workspace:*",
-        "react": "^18.3.1",
-        "@types/react": "^18.2.0",
-        "lucide-react": "^0.545.0",
-        "zustand": "^5.0.8",
-        "rimraf": "^5.0.5",
-        "tsup": "^8.0.0",
-        "typescript": "^5.3.3"
-    },
-    "keywords": [
-        "ecs",
-        "material",
-        "shader",
-        "editor"
-    ],
-    "author": "yhh",
-    "license": "MIT"
+  "name": "@esengine/material-editor",
+  "version": "1.0.0",
+  "description": "Editor components for material system",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "build:watch": "tsup --watch",
+    "type-check": "tsc --noEmit",
+    "clean": "rimraf dist"
+  },
+  "dependencies": {
+    "@esengine/material-system": "workspace:*"
+  },
+  "peerDependencies": {
+    "@esengine/editor-core": "workspace:*"
+  },
+  "devDependencies": {
+    "@esengine/ecs-framework": "workspace:*",
+    "@esengine/engine-core": "workspace:*",
+    "@esengine/editor-core": "workspace:*",
+    "@esengine/build-config": "workspace:*",
+    "react": "^18.3.1",
+    "@types/react": "^18.2.0",
+    "lucide-react": "^0.545.0",
+    "zustand": "^5.0.8",
+    "rimraf": "^5.0.5",
+    "tsup": "^8.0.0",
+    "typescript": "^5.3.3"
+  },
+  "keywords": [
+    "ecs",
+    "material",
+    "shader",
+    "editor"
+  ],
+  "author": "yhh",
+  "license": "MIT",
+  "private": true
 }

--- a/packages/mesh-3d-editor/package.json
+++ b/packages/mesh-3d-editor/package.json
@@ -1,53 +1,54 @@
 {
-    "name": "@esengine/mesh-3d-editor",
-    "version": "1.0.0",
-    "description": "Editor components for 3D mesh system",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "type": "module",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "import": "./dist/index.js"
-        }
-    },
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsup",
-        "build:watch": "tsup --watch",
-        "type-check": "tsc --noEmit",
-        "clean": "rimraf dist"
-    },
-    "dependencies": {
-        "@esengine/mesh-3d": "workspace:*"
-    },
-    "peerDependencies": {
-        "@esengine/editor-core": "workspace:*"
-    },
-    "devDependencies": {
-        "@esengine/ecs-framework": "workspace:*",
-        "@esengine/engine-core": "workspace:*",
-        "@esengine/editor-core": "workspace:*",
-        "@esengine/asset-system": "workspace:*",
-        "@esengine/build-config": "workspace:*",
-        "@tauri-apps/api": "^2.5.0",
-        "react": "^18.3.1",
-        "@types/react": "^18.2.0",
-        "lucide-react": "^0.453.0",
-        "rimraf": "^5.0.5",
-        "tsup": "^8.0.0",
-        "typescript": "^5.3.3"
-    },
-    "keywords": [
-        "ecs",
-        "mesh",
-        "3d",
-        "editor",
-        "gltf"
-    ],
-    "author": "yhh",
-    "license": "MIT"
+  "name": "@esengine/mesh-3d-editor",
+  "version": "1.0.0",
+  "description": "Editor components for 3D mesh system",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "build:watch": "tsup --watch",
+    "type-check": "tsc --noEmit",
+    "clean": "rimraf dist"
+  },
+  "dependencies": {
+    "@esengine/mesh-3d": "workspace:*"
+  },
+  "peerDependencies": {
+    "@esengine/editor-core": "workspace:*"
+  },
+  "devDependencies": {
+    "@esengine/ecs-framework": "workspace:*",
+    "@esengine/engine-core": "workspace:*",
+    "@esengine/editor-core": "workspace:*",
+    "@esengine/asset-system": "workspace:*",
+    "@esengine/build-config": "workspace:*",
+    "@tauri-apps/api": "^2.5.0",
+    "react": "^18.3.1",
+    "@types/react": "^18.2.0",
+    "lucide-react": "^0.453.0",
+    "rimraf": "^5.0.5",
+    "tsup": "^8.0.0",
+    "typescript": "^5.3.3"
+  },
+  "keywords": [
+    "ecs",
+    "mesh",
+    "3d",
+    "editor",
+    "gltf"
+  ],
+  "author": "yhh",
+  "license": "MIT",
+  "private": true
 }

--- a/packages/node-editor/package.json
+++ b/packages/node-editor/package.json
@@ -57,5 +57,6 @@
     "type": "git",
     "url": "https://github.com/esengine/esengine.git",
     "directory": "packages/node-editor"
-  }
+  },
+  "private": true
 }

--- a/packages/particle-editor/package.json
+++ b/packages/particle-editor/package.json
@@ -1,52 +1,53 @@
 {
-    "name": "@esengine/particle-editor",
-    "version": "1.0.0",
-    "description": "Editor support for @esengine/particle - particle system inspector and preview",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "type": "module",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "import": "./dist/index.js"
-        }
-    },
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsup",
-        "build:watch": "tsup --watch",
-        "type-check": "tsc --noEmit",
-        "clean": "rimraf dist"
-    },
-    "dependencies": {
-        "@esengine/particle": "workspace:*"
-    },
-    "peerDependencies": {
-        "@esengine/editor-core": "workspace:*"
-    },
-    "devDependencies": {
-        "@esengine/ecs-framework": "workspace:*",
-        "@esengine/engine-core": "workspace:*",
-        "@esengine/editor-core": "workspace:*",
-        "@esengine/editor-runtime": "workspace:*",
-        "@esengine/asset-system": "workspace:*",
-        "@esengine/build-config": "workspace:*",
-        "lucide-react": "^0.545.0",
-        "react": "^18.3.1",
-        "zustand": "^5.0.8",
-        "@types/react": "^18.3.12",
-        "rimraf": "^5.0.5",
-        "tsup": "^8.0.0",
-        "typescript": "^5.3.3"
-    },
-    "keywords": [
-        "ecs",
-        "particle",
-        "editor"
-    ],
-    "author": "yhh",
-    "license": "MIT"
+  "name": "@esengine/particle-editor",
+  "version": "1.0.0",
+  "description": "Editor support for @esengine/particle - particle system inspector and preview",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "build:watch": "tsup --watch",
+    "type-check": "tsc --noEmit",
+    "clean": "rimraf dist"
+  },
+  "dependencies": {
+    "@esengine/particle": "workspace:*"
+  },
+  "peerDependencies": {
+    "@esengine/editor-core": "workspace:*"
+  },
+  "devDependencies": {
+    "@esengine/ecs-framework": "workspace:*",
+    "@esengine/engine-core": "workspace:*",
+    "@esengine/editor-core": "workspace:*",
+    "@esengine/editor-runtime": "workspace:*",
+    "@esengine/asset-system": "workspace:*",
+    "@esengine/build-config": "workspace:*",
+    "lucide-react": "^0.545.0",
+    "react": "^18.3.1",
+    "zustand": "^5.0.8",
+    "@types/react": "^18.3.12",
+    "rimraf": "^5.0.5",
+    "tsup": "^8.0.0",
+    "typescript": "^5.3.3"
+  },
+  "keywords": [
+    "ecs",
+    "particle",
+    "editor"
+  ],
+  "author": "yhh",
+  "license": "MIT",
+  "private": true
 }

--- a/packages/physics-rapier2d-editor/package.json
+++ b/packages/physics-rapier2d-editor/package.json
@@ -1,50 +1,51 @@
 {
-    "name": "@esengine/physics-rapier2d-editor",
-    "version": "1.0.0",
-    "description": "Editor support for @esengine/physics-rapier2d - inspectors and gizmos",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "type": "module",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "import": "./dist/index.js"
-        }
-    },
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsup",
-        "build:watch": "tsup --watch",
-        "type-check": "tsc --noEmit",
-        "clean": "rimraf dist"
-    },
-    "dependencies": {
-        "@esengine/physics-rapier2d": "workspace:*"
-    },
-    "peerDependencies": {
-        "@esengine/editor-core": "workspace:*"
-    },
-    "devDependencies": {
-        "@esengine/ecs-framework": "workspace:*",
-        "@esengine/engine-core": "workspace:*",
-        "@esengine/editor-core": "workspace:*",
-        "@esengine/build-config": "workspace:*",
-        "lucide-react": "^0.545.0",
-        "react": "^18.3.1",
-        "@types/react": "^18.3.12",
-        "rimraf": "^5.0.5",
-        "tsup": "^8.0.0",
-        "typescript": "^5.3.3"
-    },
-    "keywords": [
-        "ecs",
-        "physics",
-        "rapier2d",
-        "editor"
-    ],
-    "author": "",
-    "license": "MIT"
+  "name": "@esengine/physics-rapier2d-editor",
+  "version": "1.0.0",
+  "description": "Editor support for @esengine/physics-rapier2d - inspectors and gizmos",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "build:watch": "tsup --watch",
+    "type-check": "tsc --noEmit",
+    "clean": "rimraf dist"
+  },
+  "dependencies": {
+    "@esengine/physics-rapier2d": "workspace:*"
+  },
+  "peerDependencies": {
+    "@esengine/editor-core": "workspace:*"
+  },
+  "devDependencies": {
+    "@esengine/ecs-framework": "workspace:*",
+    "@esengine/engine-core": "workspace:*",
+    "@esengine/editor-core": "workspace:*",
+    "@esengine/build-config": "workspace:*",
+    "lucide-react": "^0.545.0",
+    "react": "^18.3.1",
+    "@types/react": "^18.3.12",
+    "rimraf": "^5.0.5",
+    "tsup": "^8.0.0",
+    "typescript": "^5.3.3"
+  },
+  "keywords": [
+    "ecs",
+    "physics",
+    "rapier2d",
+    "editor"
+  ],
+  "author": "",
+  "license": "MIT",
+  "private": true
 }

--- a/packages/shader-editor/package.json
+++ b/packages/shader-editor/package.json
@@ -1,51 +1,52 @@
 {
-    "name": "@esengine/shader-editor",
-    "version": "1.0.0",
-    "description": "Shader editor with code editing, analysis, and preview",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "type": "module",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "import": "./dist/index.js"
-        }
-    },
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsup",
-        "build:watch": "tsup --watch",
-        "type-check": "tsc --noEmit",
-        "clean": "rimraf dist"
-    },
-    "dependencies": {
-        "@esengine/material-system": "workspace:*"
-    },
-    "peerDependencies": {
-        "@esengine/editor-core": "workspace:*"
-    },
-    "devDependencies": {
-        "@esengine/ecs-framework": "workspace:*",
-        "@esengine/engine-core": "workspace:*",
-        "@esengine/editor-core": "workspace:*",
-        "@esengine/build-config": "workspace:*",
-        "react": "^18.3.1",
-        "@types/react": "^18.2.0",
-        "lucide-react": "^0.453.0",
-        "zustand": "^5.0.8",
-        "rimraf": "^5.0.5",
-        "tsup": "^8.0.0",
-        "typescript": "^5.3.3"
-    },
-    "keywords": [
-        "ecs",
-        "shader",
-        "editor",
-        "glsl"
-    ],
-    "author": "yhh",
-    "license": "MIT"
+  "name": "@esengine/shader-editor",
+  "version": "1.0.0",
+  "description": "Shader editor with code editing, analysis, and preview",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "build:watch": "tsup --watch",
+    "type-check": "tsc --noEmit",
+    "clean": "rimraf dist"
+  },
+  "dependencies": {
+    "@esengine/material-system": "workspace:*"
+  },
+  "peerDependencies": {
+    "@esengine/editor-core": "workspace:*"
+  },
+  "devDependencies": {
+    "@esengine/ecs-framework": "workspace:*",
+    "@esengine/engine-core": "workspace:*",
+    "@esengine/editor-core": "workspace:*",
+    "@esengine/build-config": "workspace:*",
+    "react": "^18.3.1",
+    "@types/react": "^18.2.0",
+    "lucide-react": "^0.453.0",
+    "zustand": "^5.0.8",
+    "rimraf": "^5.0.5",
+    "tsup": "^8.0.0",
+    "typescript": "^5.3.3"
+  },
+  "keywords": [
+    "ecs",
+    "shader",
+    "editor",
+    "glsl"
+  ],
+  "author": "yhh",
+  "license": "MIT",
+  "private": true
 }

--- a/packages/sprite-editor/package.json
+++ b/packages/sprite-editor/package.json
@@ -1,51 +1,52 @@
 {
-    "name": "@esengine/sprite-editor",
-    "version": "1.0.0",
-    "description": "Editor components for sprite system",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "type": "module",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "import": "./dist/index.js"
-        }
-    },
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsup",
-        "build:watch": "tsup --watch",
-        "type-check": "tsc --noEmit",
-        "clean": "rimraf dist"
-    },
-    "dependencies": {
-        "@esengine/sprite": "workspace:*"
-    },
-    "peerDependencies": {
-        "@esengine/editor-core": "workspace:*"
-    },
-    "devDependencies": {
-        "@esengine/ecs-framework": "workspace:*",
-        "@esengine/engine-core": "workspace:*",
-        "@esengine/editor-core": "workspace:*",
-        "@esengine/material-system": "workspace:*",
-        "@esengine/build-config": "workspace:*",
-        "react": "^18.3.1",
-        "@types/react": "^18.2.0",
-        "lucide-react": "^0.453.0",
-        "rimraf": "^5.0.5",
-        "tsup": "^8.0.0",
-        "typescript": "^5.3.3"
-    },
-    "keywords": [
-        "ecs",
-        "sprite",
-        "editor",
-        "animation"
-    ],
-    "author": "yhh",
-    "license": "MIT"
+  "name": "@esengine/sprite-editor",
+  "version": "1.0.0",
+  "description": "Editor components for sprite system",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "build:watch": "tsup --watch",
+    "type-check": "tsc --noEmit",
+    "clean": "rimraf dist"
+  },
+  "dependencies": {
+    "@esengine/sprite": "workspace:*"
+  },
+  "peerDependencies": {
+    "@esengine/editor-core": "workspace:*"
+  },
+  "devDependencies": {
+    "@esengine/ecs-framework": "workspace:*",
+    "@esengine/engine-core": "workspace:*",
+    "@esengine/editor-core": "workspace:*",
+    "@esengine/material-system": "workspace:*",
+    "@esengine/build-config": "workspace:*",
+    "react": "^18.3.1",
+    "@types/react": "^18.2.0",
+    "lucide-react": "^0.453.0",
+    "rimraf": "^5.0.5",
+    "tsup": "^8.0.0",
+    "typescript": "^5.3.3"
+  },
+  "keywords": [
+    "ecs",
+    "sprite",
+    "editor",
+    "animation"
+  ],
+  "author": "yhh",
+  "license": "MIT",
+  "private": true
 }

--- a/packages/tilemap-editor/package.json
+++ b/packages/tilemap-editor/package.json
@@ -1,51 +1,52 @@
 {
-    "name": "@esengine/tilemap-editor",
-    "version": "1.0.0",
-    "description": "Editor support for @esengine/tilemap - tilemap editor, tools, and panels",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "type": "module",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "import": "./dist/index.js"
-        }
-    },
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsup",
-        "build:watch": "tsup --watch",
-        "type-check": "tsc --noEmit",
-        "clean": "rimraf dist"
-    },
-    "dependencies": {
-        "@esengine/tilemap": "workspace:*"
-    },
-    "peerDependencies": {
-        "@esengine/editor-core": "workspace:*"
-    },
-    "devDependencies": {
-        "@esengine/ecs-framework": "workspace:*",
-        "@esengine/engine-core": "workspace:*",
-        "@esengine/editor-core": "workspace:*",
-        "@esengine/editor-runtime": "workspace:*",
-        "@esengine/build-config": "workspace:*",
-        "lucide-react": "^0.545.0",
-        "react": "^18.3.1",
-        "zustand": "^5.0.8",
-        "@types/react": "^18.3.12",
-        "rimraf": "^5.0.5",
-        "tsup": "^8.0.0",
-        "typescript": "^5.3.3"
-    },
-    "keywords": [
-        "ecs",
-        "tilemap",
-        "editor"
-    ],
-    "author": "",
-    "license": "MIT"
+  "name": "@esengine/tilemap-editor",
+  "version": "1.0.0",
+  "description": "Editor support for @esengine/tilemap - tilemap editor, tools, and panels",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "build:watch": "tsup --watch",
+    "type-check": "tsc --noEmit",
+    "clean": "rimraf dist"
+  },
+  "dependencies": {
+    "@esengine/tilemap": "workspace:*"
+  },
+  "peerDependencies": {
+    "@esengine/editor-core": "workspace:*"
+  },
+  "devDependencies": {
+    "@esengine/ecs-framework": "workspace:*",
+    "@esengine/engine-core": "workspace:*",
+    "@esengine/editor-core": "workspace:*",
+    "@esengine/editor-runtime": "workspace:*",
+    "@esengine/build-config": "workspace:*",
+    "lucide-react": "^0.545.0",
+    "react": "^18.3.1",
+    "zustand": "^5.0.8",
+    "@types/react": "^18.3.12",
+    "rimraf": "^5.0.5",
+    "tsup": "^8.0.0",
+    "typescript": "^5.3.3"
+  },
+  "keywords": [
+    "ecs",
+    "tilemap",
+    "editor"
+  ],
+  "author": "",
+  "license": "MIT",
+  "private": true
 }

--- a/packages/world-streaming-editor/package.json
+++ b/packages/world-streaming-editor/package.json
@@ -1,51 +1,52 @@
 {
-    "name": "@esengine/world-streaming-editor",
-    "version": "1.0.0",
-    "description": "Editor support for @esengine/world-streaming - chunk visualization and inspector",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "type": "module",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "import": "./dist/index.js"
-        }
-    },
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsup",
-        "build:watch": "tsup --watch",
-        "type-check": "tsc --noEmit",
-        "clean": "rimraf dist"
-    },
-    "dependencies": {
-        "@esengine/world-streaming": "workspace:*"
-    },
-    "peerDependencies": {
-        "@esengine/editor-core": "workspace:*"
-    },
-    "devDependencies": {
-        "@esengine/ecs-framework": "workspace:*",
-        "@esengine/engine-core": "workspace:*",
-        "@esengine/editor-core": "workspace:*",
-        "@esengine/build-config": "workspace:*",
-        "lucide-react": "^0.545.0",
-        "react": "^18.3.1",
-        "zustand": "^5.0.8",
-        "@types/react": "^18.3.12",
-        "rimraf": "^5.0.5",
-        "tsup": "^8.0.0",
-        "typescript": "^5.3.3"
-    },
-    "keywords": [
-        "ecs",
-        "world-streaming",
-        "chunk",
-        "editor"
-    ],
-    "author": "ESEngine",
-    "license": "MIT"
+  "name": "@esengine/world-streaming-editor",
+  "version": "1.0.0",
+  "description": "Editor support for @esengine/world-streaming - chunk visualization and inspector",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "build:watch": "tsup --watch",
+    "type-check": "tsc --noEmit",
+    "clean": "rimraf dist"
+  },
+  "dependencies": {
+    "@esengine/world-streaming": "workspace:*"
+  },
+  "peerDependencies": {
+    "@esengine/editor-core": "workspace:*"
+  },
+  "devDependencies": {
+    "@esengine/ecs-framework": "workspace:*",
+    "@esengine/engine-core": "workspace:*",
+    "@esengine/editor-core": "workspace:*",
+    "@esengine/build-config": "workspace:*",
+    "lucide-react": "^0.545.0",
+    "react": "^18.3.1",
+    "zustand": "^5.0.8",
+    "@types/react": "^18.3.12",
+    "rimraf": "^5.0.5",
+    "tsup": "^8.0.0",
+    "typescript": "^5.3.3"
+  },
+  "keywords": [
+    "ecs",
+    "world-streaming",
+    "chunk",
+    "editor"
+  ],
+  "author": "ESEngine",
+  "license": "MIT",
+  "private": true
 }


### PR DESCRIPTION
## Problem

Changesets 验证失败，因为：
- 忽略的包被其他包依赖
- 依赖规则：如果 A 依赖被忽略的 B，那么 A 也必须被忽略

## Solution

1. 简化 ignore 配置，只保留 `editor-app`（唯一需要 ignore 的包）
2. 设置不需要发布的包为 `private: true`：
   - `build-config`, `engine`, `ecs-engine-bindgen`
   - `editor-core`, `editor-runtime`
   - 所有 `*-editor` 插件包

## Benefit

- Changesets 验证通过
- `private: true` 的包不会被发布到 NPM
- 其他包可以正常管理版本和发布