### PR TITLE
fix(ci): update typedoc path and add workflow_dispatch

### DIFF
--- a/.github/workflows/release-changesets.yml
+++ b/.github/workflows/release-changesets.yml
@@ -7,6 +7,9 @@ on:
     paths:
       - '.changeset/**'
       - 'packages/*/package.json'
+      - 'packages/*/*/package.json'
+      - 'packages/*/*/*/package.json'
+  workflow_dispatch:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,5 +1,5 @@
 {
-  "entryPoints": ["./packages/core/src/index.ts"],
+  "entryPoints": ["./packages/framework/core/src/index.ts"],
   "out": "./docs/api",
   "plugin": ["typedoc-plugin-markdown"],
   "readme": "none",


### PR DESCRIPTION
## Summary

- Fix typedoc entry point path (packages/core -> packages/framework/core)
- Add `workflow_dispatch` to release-changesets workflow for manual triggering
- Add deeper package paths to trigger on nested packages

## Why

1. **TypeDoc error**: `packages/core` was moved to `packages/framework/core`
2. **Release workflow not triggering**: Nested packages like `packages/tools/cli` didn't match `packages/*/package.json`
3. **Manual trigger**: Added `workflow_dispatch` to allow manual re-runs