### PR TITLE
fix(ci): run on all PRs with conditional skip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,18 +13,31 @@ on:
       - '.github/workflows/ci.yml'
   pull_request:
     branches: [ master, main, develop ]
-    paths:
-      - 'packages/**'
-      - 'package.json'
-      - 'pnpm-lock.yaml'
-      - 'tsconfig.json'
-      - 'turbo.json'
-      - 'jest.config.*'
-      - '.github/workflows/ci.yml'
-      - '.changeset/**'
+    # Run on all PRs to satisfy branch protection, but skip build if no code changes
 
 jobs:
+  # Check if we need to run the full CI
+  check-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - 'packages/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'tsconfig.json'
+              - 'turbo.json'
+              - 'jest.config.*'
+
   ci:
+    needs: check-changes
+    if: needs.check-changes.outputs.should-run == 'true'
     runs-on: ubuntu-latest
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}


### PR DESCRIPTION
## Problem

CI workflow has paths filter, so PRs that only change `.changeset/` files don't trigger CI, causing "Waiting for status" in branch protection.

## Solution

- Remove paths filter from `pull_request` trigger (run on ALL PRs)
- Add `check-changes` job using `dorny/paths-filter`
- Skip full CI build if no code files changed
- Branch protection sees CI as "passed" even when skipped

This allows Release PRs and docs-only PRs to be merged.