### PR TITLE
fix: add private:true to packages not meant for npm

### DIFF
--- a/packages/engine/asset-system/package.json
+++ b/packages/engine/asset-system/package.json
@@ -48,5 +48,6 @@
   "dependencies": {
     "@types/pako": "^2.0.4",
     "pako": "^2.1.0"
-  }
+  },
+  "private": true
 }

--- a/packages/engine/engine-core/package.json
+++ b/packages/engine/engine-core/package.json
@@ -1,48 +1,49 @@
 {
-    "name": "@esengine/engine-core",
-    "version": "1.0.0",
-    "description": "Engine core components - Transform, etc.",
-    "esengine": {
-        "plugin": true,
-        "pluginExport": "EnginePlugin",
-        "category": "core",
-        "isEnginePlugin": true
-    },
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "type": "module",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "import": "./dist/index.js"
-        }
-    },
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsup",
-        "build:watch": "tsup --watch",
-        "type-check": "tsc --noEmit",
-        "clean": "rimraf dist"
-    },
-    "dependencies": {
-        "@esengine/ecs-framework": "workspace:*",
-        "@esengine/ecs-framework-math": "workspace:*",
-        "@esengine/platform-common": "workspace:*"
-    },
-    "devDependencies": {
-        "@esengine/build-config": "workspace:*",
-        "rimraf": "^5.0.5",
-        "tsup": "^8.0.0",
-        "typescript": "^5.3.3"
-    },
-    "keywords": [
-        "ecs",
-        "engine",
-        "transform"
-    ],
-    "author": "yhh",
-    "license": "MIT"
+  "name": "@esengine/engine-core",
+  "version": "1.0.0",
+  "description": "Engine core components - Transform, etc.",
+  "esengine": {
+    "plugin": true,
+    "pluginExport": "EnginePlugin",
+    "category": "core",
+    "isEnginePlugin": true
+  },
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "build:watch": "tsup --watch",
+    "type-check": "tsc --noEmit",
+    "clean": "rimraf dist"
+  },
+  "dependencies": {
+    "@esengine/ecs-framework": "workspace:*",
+    "@esengine/ecs-framework-math": "workspace:*",
+    "@esengine/platform-common": "workspace:*"
+  },
+  "devDependencies": {
+    "@esengine/build-config": "workspace:*",
+    "rimraf": "^5.0.5",
+    "tsup": "^8.0.0",
+    "typescript": "^5.3.3"
+  },
+  "keywords": [
+    "ecs",
+    "engine",
+    "transform"
+  ],
+  "author": "yhh",
+  "license": "MIT",
+  "private": true
 }

--- a/packages/engine/material-system/package.json
+++ b/packages/engine/material-system/package.json
@@ -1,48 +1,49 @@
 {
-    "name": "@esengine/material-system",
-    "version": "1.0.0",
-    "description": "Material and shader system for ES Engine",
-    "esengine": {
-        "plugin": true,
-        "pluginExport": "MaterialSystemPlugin",
-        "category": "rendering",
-        "isEnginePlugin": true
-    },
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "type": "module",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "import": "./dist/index.js"
-        }
-    },
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsup",
-        "build:watch": "tsup --watch",
-        "type-check": "tsc --noEmit",
-        "clean": "rimraf dist"
-    },
-    "devDependencies": {
-        "@esengine/ecs-framework": "workspace:*",
-        "@esengine/asset-system": "workspace:*",
-        "@esengine/engine-core": "workspace:*",
-        "@esengine/build-config": "workspace:*",
-        "rimraf": "^5.0.5",
-        "tsup": "^8.0.0",
-        "typescript": "^5.3.3"
-    },
-    "keywords": [
-        "ecs",
-        "material",
-        "shader",
-        "webgl",
-        "rendering"
-    ],
-    "author": "yhh",
-    "license": "MIT"
+  "name": "@esengine/material-system",
+  "version": "1.0.0",
+  "description": "Material and shader system for ES Engine",
+  "esengine": {
+    "plugin": true,
+    "pluginExport": "MaterialSystemPlugin",
+    "category": "rendering",
+    "isEnginePlugin": true
+  },
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "build:watch": "tsup --watch",
+    "type-check": "tsc --noEmit",
+    "clean": "rimraf dist"
+  },
+  "devDependencies": {
+    "@esengine/ecs-framework": "workspace:*",
+    "@esengine/asset-system": "workspace:*",
+    "@esengine/engine-core": "workspace:*",
+    "@esengine/build-config": "workspace:*",
+    "rimraf": "^5.0.5",
+    "tsup": "^8.0.0",
+    "typescript": "^5.3.3"
+  },
+  "keywords": [
+    "ecs",
+    "material",
+    "shader",
+    "webgl",
+    "rendering"
+  ],
+  "author": "yhh",
+  "license": "MIT",
+  "private": true
 }

--- a/packages/engine/platform-common/package.json
+++ b/packages/engine/platform-common/package.json
@@ -46,5 +46,6 @@
     "type": "git",
     "url": "https://github.com/esengine/esengine.git",
     "directory": "packages/platform-common"
-  }
+  },
+  "private": true
 }

--- a/packages/engine/platform-web/package.json
+++ b/packages/engine/platform-web/package.json
@@ -57,5 +57,6 @@
     "type": "git",
     "url": "https://github.com/esengine/esengine.git",
     "directory": "packages/platform-web"
-  }
+  },
+  "private": true
 }

--- a/packages/engine/platform-wechat/package.json
+++ b/packages/engine/platform-wechat/package.json
@@ -52,5 +52,6 @@
     "type": "git",
     "url": "https://github.com/esengine/esengine.git",
     "directory": "packages/platform-wechat"
-  }
+  },
+  "private": true
 }

--- a/packages/engine/runtime-core/package.json
+++ b/packages/engine/runtime-core/package.json
@@ -1,45 +1,46 @@
 {
-    "name": "@esengine/runtime-core",
-    "version": "1.0.0",
-    "description": "Runtime core - plugin management and system initialization",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "type": "module",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "import": "./dist/index.js"
-        }
-    },
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsup",
-        "build:watch": "tsup --watch",
-        "type-check": "tsc --noEmit",
-        "clean": "rimraf dist"
-    },
-    "dependencies": {
-        "@esengine/ecs-framework": "workspace:*",
-        "@esengine/ecs-framework-math": "workspace:*",
-        "@esengine/ecs-engine-bindgen": "workspace:*",
-        "@esengine/engine-core": "workspace:*",
-        "@esengine/asset-system": "workspace:*",
-        "@esengine/platform-common": "workspace:*"
-    },
-    "devDependencies": {
-        "@esengine/build-config": "workspace:*",
-        "rimraf": "^5.0.5",
-        "tsup": "^8.0.0",
-        "typescript": "^5.3.3"
-    },
-    "keywords": [
-        "ecs",
-        "runtime",
-        "plugin"
-    ],
-    "author": "yhh",
-    "license": "MIT"
+  "name": "@esengine/runtime-core",
+  "version": "1.0.0",
+  "description": "Runtime core - plugin management and system initialization",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "build:watch": "tsup --watch",
+    "type-check": "tsc --noEmit",
+    "clean": "rimraf dist"
+  },
+  "dependencies": {
+    "@esengine/ecs-framework": "workspace:*",
+    "@esengine/ecs-framework-math": "workspace:*",
+    "@esengine/ecs-engine-bindgen": "workspace:*",
+    "@esengine/engine-core": "workspace:*",
+    "@esengine/asset-system": "workspace:*",
+    "@esengine/platform-common": "workspace:*"
+  },
+  "devDependencies": {
+    "@esengine/build-config": "workspace:*",
+    "rimraf": "^5.0.5",
+    "tsup": "^8.0.0",
+    "typescript": "^5.3.3"
+  },
+  "keywords": [
+    "ecs",
+    "runtime",
+    "plugin"
+  ],
+  "author": "yhh",
+  "license": "MIT",
+  "private": true
 }

--- a/packages/engine/script-runtime/package.json
+++ b/packages/engine/script-runtime/package.json
@@ -1,56 +1,57 @@
 {
-    "name": "@esengine/script-runtime",
-    "version": "1.0.0",
-    "description": "Server-side blueprint execution for programmable strategy games | 服务器端蓝图执行，用于可编程策略游戏",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "type": "module",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "import": "./dist/index.js"
-        }
-    },
-    "files": [
-        "dist",
-        "module.json"
-    ],
-    "scripts": {
-        "clean": "rimraf dist tsconfig.tsbuildinfo",
-        "build": "tsup",
-        "build:watch": "tsup --watch",
-        "type-check": "tsc --noEmit"
-    },
-    "keywords": [
-        "ecs",
-        "script-runtime",
-        "screeps",
-        "server-side",
-        "game-engine"
-    ],
-    "author": "yhh",
-    "license": "MIT",
-    "devDependencies": {
-        "@esengine/ecs-framework": "workspace:*",
-        "@esengine/engine-core": "workspace:*",
-        "@esengine/blueprint": "workspace:*",
-        "@esengine/build-config": "workspace:*",
-        "@types/node": "^20.19.17",
-        "rimraf": "^5.0.0",
-        "tsup": "^8.0.0",
-        "typescript": "^5.8.3"
-    },
-    "dependencies": {
-        "tslib": "^2.8.1"
-    },
-    "publishConfig": {
-        "access": "public",
-        "registry": "https://registry.npmjs.org/"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/esengine/esengine.git",
-        "directory": "packages/script-runtime"
+  "name": "@esengine/script-runtime",
+  "version": "1.0.0",
+  "description": "Server-side blueprint execution for programmable strategy games | 服务器端蓝图执行，用于可编程策略游戏",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
     }
+  },
+  "files": [
+    "dist",
+    "module.json"
+  ],
+  "scripts": {
+    "clean": "rimraf dist tsconfig.tsbuildinfo",
+    "build": "tsup",
+    "build:watch": "tsup --watch",
+    "type-check": "tsc --noEmit"
+  },
+  "keywords": [
+    "ecs",
+    "script-runtime",
+    "screeps",
+    "server-side",
+    "game-engine"
+  ],
+  "author": "yhh",
+  "license": "MIT",
+  "devDependencies": {
+    "@esengine/ecs-framework": "workspace:*",
+    "@esengine/engine-core": "workspace:*",
+    "@esengine/blueprint": "workspace:*",
+    "@esengine/build-config": "workspace:*",
+    "@types/node": "^20.19.17",
+    "rimraf": "^5.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.8.3"
+  },
+  "dependencies": {
+    "tslib": "^2.8.1"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/esengine/esengine.git",
+    "directory": "packages/script-runtime"
+  },
+  "private": true
 }

--- a/packages/physics/physics-rapier2d/package.json
+++ b/packages/physics/physics-rapier2d/package.json
@@ -1,65 +1,66 @@
 {
-    "name": "@esengine/physics-rapier2d",
-    "version": "1.0.0",
-    "description": "Deterministic 2D physics engine based on Rapier2D with enhanced-determinism",
-    "esengine": {
-        "plugin": true,
-        "pluginExport": "PhysicsPlugin",
-        "category": "physics"
+  "name": "@esengine/physics-rapier2d",
+  "version": "1.0.0",
+  "description": "Deterministic 2D physics engine based on Rapier2D with enhanced-determinism",
+  "esengine": {
+    "plugin": true,
+    "pluginExport": "PhysicsPlugin",
+    "category": "physics"
+  },
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
     },
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "type": "module",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "import": "./dist/index.js"
-        },
-        "./runtime": {
-            "types": "./dist/runtime.d.ts",
-            "import": "./dist/runtime.js"
-        }
-    },
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "clean": "rimraf dist tsconfig.tsbuildinfo",
-        "build": "tsup",
-        "build:watch": "tsup --watch",
-        "type-check": "tsc --noEmit"
-    },
-    "keywords": [
-        "ecs",
-        "physics",
-        "rapier2d",
-        "deterministic",
-        "game-physics",
-        "2d-physics"
-    ],
-    "author": "yhh",
-    "license": "MIT",
-    "dependencies": {
-        "@esengine/rapier2d": "workspace:*",
-        "@esengine/platform-common": "workspace:*"
-    },
-    "devDependencies": {
-        "@esengine/ecs-framework": "workspace:*",
-        "@esengine/ecs-framework-math": "workspace:*",
-        "@esengine/engine-core": "workspace:*",
-        "@esengine/build-config": "workspace:*",
-        "rimraf": "^5.0.0",
-        "tsup": "^8.0.0",
-        "typescript": "^5.8.3"
-    },
-    "publishConfig": {
-        "access": "public",
-        "registry": "https://registry.npmjs.org/"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/esengine/esengine.git",
-        "directory": "packages/physics-rapier2d"
+    "./runtime": {
+      "types": "./dist/runtime.d.ts",
+      "import": "./dist/runtime.js"
     }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rimraf dist tsconfig.tsbuildinfo",
+    "build": "tsup",
+    "build:watch": "tsup --watch",
+    "type-check": "tsc --noEmit"
+  },
+  "keywords": [
+    "ecs",
+    "physics",
+    "rapier2d",
+    "deterministic",
+    "game-physics",
+    "2d-physics"
+  ],
+  "author": "yhh",
+  "license": "MIT",
+  "dependencies": {
+    "@esengine/rapier2d": "workspace:*",
+    "@esengine/platform-common": "workspace:*"
+  },
+  "devDependencies": {
+    "@esengine/ecs-framework": "workspace:*",
+    "@esengine/ecs-framework-math": "workspace:*",
+    "@esengine/engine-core": "workspace:*",
+    "@esengine/build-config": "workspace:*",
+    "rimraf": "^5.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/esengine/esengine.git",
+    "directory": "packages/physics-rapier2d"
+  },
+  "private": true
 }

--- a/packages/physics/rapier2d/package.json
+++ b/packages/physics/rapier2d/package.json
@@ -27,5 +27,6 @@
     "rimraf": "^5.0.0",
     "tsup": "^8.0.0",
     "typescript": "^5.0.0"
-  }
+  },
+  "private": true
 }

--- a/packages/rendering/audio/package.json
+++ b/packages/rendering/audio/package.json
@@ -1,46 +1,47 @@
 {
-    "name": "@esengine/audio",
-    "version": "1.0.0",
-    "description": "ECS-based audio system",
-    "esengine": {
-        "plugin": true,
-        "pluginExport": "AudioPlugin",
-        "category": "audio",
-        "isEnginePlugin": true
-    },
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "type": "module",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "import": "./dist/index.js"
-        }
-    },
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsup",
-        "build:watch": "tsup --watch",
-        "type-check": "tsc --noEmit",
-        "clean": "rimraf dist"
-    },
-    "devDependencies": {
-        "@esengine/ecs-framework": "workspace:*",
-        "@esengine/engine-core": "workspace:*",
-        "@esengine/build-config": "workspace:*",
-        "rimraf": "^5.0.5",
-        "tsup": "^8.0.0",
-        "typescript": "^5.3.3"
-    },
-    "keywords": [
-        "ecs",
-        "audio",
-        "sound",
-        "music"
-    ],
-    "author": "yhh",
-    "license": "MIT"
+  "name": "@esengine/audio",
+  "version": "1.0.0",
+  "description": "ECS-based audio system",
+  "esengine": {
+    "plugin": true,
+    "pluginExport": "AudioPlugin",
+    "category": "audio",
+    "isEnginePlugin": true
+  },
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "build:watch": "tsup --watch",
+    "type-check": "tsc --noEmit",
+    "clean": "rimraf dist"
+  },
+  "devDependencies": {
+    "@esengine/ecs-framework": "workspace:*",
+    "@esengine/engine-core": "workspace:*",
+    "@esengine/build-config": "workspace:*",
+    "rimraf": "^5.0.5",
+    "tsup": "^8.0.0",
+    "typescript": "^5.3.3"
+  },
+  "keywords": [
+    "ecs",
+    "audio",
+    "sound",
+    "music"
+  ],
+  "author": "yhh",
+  "license": "MIT",
+  "private": true
 }

--- a/packages/rendering/camera/package.json
+++ b/packages/rendering/camera/package.json
@@ -1,48 +1,49 @@
 {
-    "name": "@esengine/camera",
-    "version": "1.0.0",
-    "description": "Camera component and systems for 2D/3D rendering",
-    "esengine": {
-        "plugin": true,
-        "pluginExport": "CameraPlugin",
-        "category": "core",
-        "isEnginePlugin": true
-    },
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "type": "module",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "import": "./dist/index.js"
-        }
-    },
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsup",
-        "build:watch": "tsup --watch",
-        "type-check": "tsc --noEmit",
-        "clean": "rimraf dist"
-    },
-    "devDependencies": {
-        "@esengine/ecs-framework": "workspace:*",
-        "@esengine/ecs-framework-math": "workspace:*",
-        "@esengine/engine-core": "workspace:*",
-        "@esengine/build-config": "workspace:*",
-        "rimraf": "^5.0.5",
-        "tsup": "^8.0.0",
-        "typescript": "^5.3.3"
-    },
-    "keywords": [
-        "ecs",
-        "camera",
-        "2d",
-        "3d",
-        "rendering"
-    ],
-    "author": "yhh",
-    "license": "MIT"
+  "name": "@esengine/camera",
+  "version": "1.0.0",
+  "description": "Camera component and systems for 2D/3D rendering",
+  "esengine": {
+    "plugin": true,
+    "pluginExport": "CameraPlugin",
+    "category": "core",
+    "isEnginePlugin": true
+  },
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "build:watch": "tsup --watch",
+    "type-check": "tsc --noEmit",
+    "clean": "rimraf dist"
+  },
+  "devDependencies": {
+    "@esengine/ecs-framework": "workspace:*",
+    "@esengine/ecs-framework-math": "workspace:*",
+    "@esengine/engine-core": "workspace:*",
+    "@esengine/build-config": "workspace:*",
+    "rimraf": "^5.0.5",
+    "tsup": "^8.0.0",
+    "typescript": "^5.3.3"
+  },
+  "keywords": [
+    "ecs",
+    "camera",
+    "2d",
+    "3d",
+    "rendering"
+  ],
+  "author": "yhh",
+  "license": "MIT",
+  "private": true
 }

--- a/packages/rendering/effect/package.json
+++ b/packages/rendering/effect/package.json
@@ -1,40 +1,41 @@
 {
-    "name": "@esengine/effect",
-    "version": "1.0.0",
-    "description": "Effect system for ECS Framework / ECS 框架的效果系统",
-    "type": "module",
-    "main": "./dist/index.js",
-    "module": "./dist/index.js",
-    "types": "./dist/index.d.ts",
-    "exports": {
-        ".": {
-            "import": "./dist/index.js",
-            "types": "./dist/index.d.ts"
-        }
-    },
-    "files": [
-        "dist",
-        "module.json"
-    ],
-    "scripts": {
-        "build": "tsup",
-        "build:watch": "tsup --watch",
-        "type-check": "tsc --noEmit",
-        "clean": "rimraf dist"
-    },
-    "dependencies": {
-        "tslib": "^2.8.1"
-    },
-    "devDependencies": {
-        "@esengine/ecs-framework": "workspace:*",
-        "@esengine/blueprint": "workspace:*",
-        "@esengine/build-config": "workspace:*",
-        "@types/node": "^20.19.17",
-        "rimraf": "^5.0.0",
-        "tsup": "^8.0.0",
-        "typescript": "^5.8.3"
-    },
-    "publishConfig": {
-        "access": "public"
+  "name": "@esengine/effect",
+  "version": "1.0.0",
+  "description": "Effect system for ECS Framework / ECS 框架的效果系统",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
     }
+  },
+  "files": [
+    "dist",
+    "module.json"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "build:watch": "tsup --watch",
+    "type-check": "tsc --noEmit",
+    "clean": "rimraf dist"
+  },
+  "dependencies": {
+    "tslib": "^2.8.1"
+  },
+  "devDependencies": {
+    "@esengine/ecs-framework": "workspace:*",
+    "@esengine/blueprint": "workspace:*",
+    "@esengine/build-config": "workspace:*",
+    "@types/node": "^20.19.17",
+    "rimraf": "^5.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "private": true
 }

--- a/packages/rendering/fairygui/package.json
+++ b/packages/rendering/fairygui/package.json
@@ -1,54 +1,55 @@
 {
-    "name": "@esengine/fairygui",
-    "version": "1.0.0",
-    "description": "FairyGUI ECS integration - FairyGUI Editor compatible UI system",
-    "esengine": {
-        "plugin": true,
-        "pluginExport": "FGUIPlugin",
-        "editorPackage": "@esengine/fairygui-editor",
-        "category": "ui",
-        "isEngineModule": true
-    },
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "type": "module",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "import": "./dist/index.js"
-        }
-    },
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsup",
-        "build:watch": "tsup --watch",
-        "type-check": "tsc --noEmit",
-        "clean": "rimraf dist"
-    },
-    "dependencies": {
-        "@esengine/asset-system": "workspace:*",
-        "@esengine/ecs-framework-math": "workspace:*"
-    },
-    "devDependencies": {
-        "@esengine/ecs-framework": "workspace:*",
-        "@esengine/engine-core": "workspace:*",
-        "@esengine/ecs-engine-bindgen": "workspace:*",
-        "@esengine/material-system": "workspace:*",
-        "@esengine/build-config": "workspace:*",
-        "rimraf": "^5.0.5",
-        "tsup": "^8.0.0",
-        "typescript": "^5.3.3"
-    },
-    "keywords": [
-        "ecs",
-        "fairygui",
-        "ui",
-        "webgpu",
-        "game-ui"
-    ],
-    "author": "",
-    "license": "MIT"
+  "name": "@esengine/fairygui",
+  "version": "1.0.0",
+  "description": "FairyGUI ECS integration - FairyGUI Editor compatible UI system",
+  "esengine": {
+    "plugin": true,
+    "pluginExport": "FGUIPlugin",
+    "editorPackage": "@esengine/fairygui-editor",
+    "category": "ui",
+    "isEngineModule": true
+  },
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "build:watch": "tsup --watch",
+    "type-check": "tsc --noEmit",
+    "clean": "rimraf dist"
+  },
+  "dependencies": {
+    "@esengine/asset-system": "workspace:*",
+    "@esengine/ecs-framework-math": "workspace:*"
+  },
+  "devDependencies": {
+    "@esengine/ecs-framework": "workspace:*",
+    "@esengine/engine-core": "workspace:*",
+    "@esengine/ecs-engine-bindgen": "workspace:*",
+    "@esengine/material-system": "workspace:*",
+    "@esengine/build-config": "workspace:*",
+    "rimraf": "^5.0.5",
+    "tsup": "^8.0.0",
+    "typescript": "^5.3.3"
+  },
+  "keywords": [
+    "ecs",
+    "fairygui",
+    "ui",
+    "webgpu",
+    "game-ui"
+  ],
+  "author": "",
+  "license": "MIT",
+  "private": true
 }

--- a/packages/rendering/mesh-3d/package.json
+++ b/packages/rendering/mesh-3d/package.json
@@ -1,49 +1,50 @@
 {
-    "name": "@esengine/mesh-3d",
-    "version": "1.0.0",
-    "description": "ECS-based 3D mesh rendering system with GLTF support",
-    "esengine": {
-        "plugin": true,
-        "pluginExport": "Mesh3DPlugin",
-        "category": "rendering",
-        "isEnginePlugin": true
-    },
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "type": "module",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "import": "./dist/index.js"
-        }
-    },
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsup",
-        "build:watch": "tsup --watch",
-        "type-check": "tsc --noEmit",
-        "clean": "rimraf dist"
-    },
-    "devDependencies": {
-        "@esengine/ecs-framework": "workspace:*",
-        "@esengine/asset-system": "workspace:*",
-        "@esengine/engine-core": "workspace:*",
-        "@esengine/ecs-engine-bindgen": "workspace:*",
-        "@esengine/build-config": "workspace:*",
-        "rimraf": "^5.0.5",
-        "tsup": "^8.0.0",
-        "typescript": "^5.3.3"
-    },
-    "keywords": [
-        "ecs",
-        "mesh",
-        "3d",
-        "gltf",
-        "webgl"
-    ],
-    "author": "yhh",
-    "license": "MIT"
+  "name": "@esengine/mesh-3d",
+  "version": "1.0.0",
+  "description": "ECS-based 3D mesh rendering system with GLTF support",
+  "esengine": {
+    "plugin": true,
+    "pluginExport": "Mesh3DPlugin",
+    "category": "rendering",
+    "isEnginePlugin": true
+  },
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "build:watch": "tsup --watch",
+    "type-check": "tsc --noEmit",
+    "clean": "rimraf dist"
+  },
+  "devDependencies": {
+    "@esengine/ecs-framework": "workspace:*",
+    "@esengine/asset-system": "workspace:*",
+    "@esengine/engine-core": "workspace:*",
+    "@esengine/ecs-engine-bindgen": "workspace:*",
+    "@esengine/build-config": "workspace:*",
+    "rimraf": "^5.0.5",
+    "tsup": "^8.0.0",
+    "typescript": "^5.3.3"
+  },
+  "keywords": [
+    "ecs",
+    "mesh",
+    "3d",
+    "gltf",
+    "webgl"
+  ],
+  "author": "yhh",
+  "license": "MIT",
+  "private": true
 }

--- a/packages/rendering/particle/package.json
+++ b/packages/rendering/particle/package.json
@@ -1,62 +1,63 @@
 {
-    "name": "@esengine/particle",
-    "version": "1.0.0",
-    "description": "ECS-based 2D particle system",
-    "esengine": {
-        "plugin": true,
-        "pluginExport": "ParticlePlugin",
-        "category": "rendering",
-        "isEnginePlugin": true
-    },
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "type": "module",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "import": "./dist/index.js"
-        }
-    },
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsup",
-        "build:watch": "tsup --watch",
-        "type-check": "tsc --noEmit",
-        "clean": "rimraf dist"
-    },
-    "dependencies": {
-        "@esengine/asset-system": "workspace:*"
-    },
-    "peerDependencies": {
-        "@esengine/physics-rapier2d": "workspace:*"
-    },
-    "peerDependenciesMeta": {
-        "@esengine/physics-rapier2d": {
-            "optional": true
-        }
-    },
-    "devDependencies": {
-        "@esengine/ecs-framework": "workspace:*",
-        "@esengine/ecs-framework-math": "workspace:*",
-        "@esengine/engine-core": "workspace:*",
-        "@esengine/ecs-engine-bindgen": "workspace:*",
-        "@esengine/physics-rapier2d": "workspace:*",
-        "@esengine/camera": "workspace:*",
-        "@esengine/build-config": "workspace:*",
-        "rimraf": "^5.0.5",
-        "tsup": "^8.0.0",
-        "typescript": "^5.3.3"
-    },
-    "keywords": [
-        "ecs",
-        "particle",
-        "2d",
-        "webgl",
-        "effects"
-    ],
-    "author": "yhh",
-    "license": "MIT"
+  "name": "@esengine/particle",
+  "version": "1.0.0",
+  "description": "ECS-based 2D particle system",
+  "esengine": {
+    "plugin": true,
+    "pluginExport": "ParticlePlugin",
+    "category": "rendering",
+    "isEnginePlugin": true
+  },
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "build:watch": "tsup --watch",
+    "type-check": "tsc --noEmit",
+    "clean": "rimraf dist"
+  },
+  "dependencies": {
+    "@esengine/asset-system": "workspace:*"
+  },
+  "peerDependencies": {
+    "@esengine/physics-rapier2d": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@esengine/physics-rapier2d": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@esengine/ecs-framework": "workspace:*",
+    "@esengine/ecs-framework-math": "workspace:*",
+    "@esengine/engine-core": "workspace:*",
+    "@esengine/ecs-engine-bindgen": "workspace:*",
+    "@esengine/physics-rapier2d": "workspace:*",
+    "@esengine/camera": "workspace:*",
+    "@esengine/build-config": "workspace:*",
+    "rimraf": "^5.0.5",
+    "tsup": "^8.0.0",
+    "typescript": "^5.3.3"
+  },
+  "keywords": [
+    "ecs",
+    "particle",
+    "2d",
+    "webgl",
+    "effects"
+  ],
+  "author": "yhh",
+  "license": "MIT",
+  "private": true
 }

--- a/packages/rendering/sprite/package.json
+++ b/packages/rendering/sprite/package.json
@@ -1,49 +1,50 @@
 {
-    "name": "@esengine/sprite",
-    "version": "1.0.0",
-    "description": "ECS-based 2D sprite rendering and animation system",
-    "esengine": {
-        "plugin": true,
-        "pluginExport": "SpritePlugin",
-        "category": "rendering",
-        "isEnginePlugin": true
-    },
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "type": "module",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "import": "./dist/index.js"
-        }
-    },
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsup",
-        "build:watch": "tsup --watch",
-        "type-check": "tsc --noEmit",
-        "clean": "rimraf dist"
-    },
-    "devDependencies": {
-        "@esengine/ecs-framework": "workspace:*",
-        "@esengine/asset-system": "workspace:*",
-        "@esengine/engine-core": "workspace:*",
-        "@esengine/material-system": "workspace:*",
-        "@esengine/build-config": "workspace:*",
-        "rimraf": "^5.0.5",
-        "tsup": "^8.0.0",
-        "typescript": "^5.3.3"
-    },
-    "keywords": [
-        "ecs",
-        "sprite",
-        "animation",
-        "2d",
-        "webgl"
-    ],
-    "author": "yhh",
-    "license": "MIT"
+  "name": "@esengine/sprite",
+  "version": "1.0.0",
+  "description": "ECS-based 2D sprite rendering and animation system",
+  "esengine": {
+    "plugin": true,
+    "pluginExport": "SpritePlugin",
+    "category": "rendering",
+    "isEnginePlugin": true
+  },
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "build:watch": "tsup --watch",
+    "type-check": "tsc --noEmit",
+    "clean": "rimraf dist"
+  },
+  "devDependencies": {
+    "@esengine/ecs-framework": "workspace:*",
+    "@esengine/asset-system": "workspace:*",
+    "@esengine/engine-core": "workspace:*",
+    "@esengine/material-system": "workspace:*",
+    "@esengine/build-config": "workspace:*",
+    "rimraf": "^5.0.5",
+    "tsup": "^8.0.0",
+    "typescript": "^5.3.3"
+  },
+  "keywords": [
+    "ecs",
+    "sprite",
+    "animation",
+    "2d",
+    "webgl"
+  ],
+  "author": "yhh",
+  "license": "MIT",
+  "private": true
 }

--- a/packages/rendering/tilemap/package.json
+++ b/packages/rendering/tilemap/package.json
@@ -1,60 +1,61 @@
 {
-    "name": "@esengine/tilemap",
-    "version": "1.0.0",
-    "description": "Tilemap system for ECS Framework - supports Tiled editor import",
-    "esengine": {
-        "plugin": true,
-        "pluginExport": "TilemapPlugin",
-        "category": "tilemap"
-    },
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "type": "module",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "import": "./dist/index.js"
-        }
-    },
-    "files": [
-        "dist"
-    ],
-    "keywords": [
-        "ecs",
-        "tilemap",
-        "tiled",
-        "game-engine",
-        "2d",
-        "typescript"
-    ],
-    "scripts": {
-        "clean": "rimraf dist tsconfig.tsbuildinfo",
-        "build": "tsup",
-        "build:watch": "tsup --watch",
-        "type-check": "tsc --noEmit",
-        "rebuild": "npm run clean && npm run build"
-    },
-    "author": "yhh",
-    "license": "MIT",
-    "devDependencies": {
-        "@esengine/ecs-framework": "workspace:*",
-        "@esengine/ecs-framework-math": "workspace:*",
-        "@esengine/asset-system": "workspace:*",
-        "@esengine/engine-core": "workspace:*",
-        "@esengine/ecs-engine-bindgen": "workspace:*",
-        "@esengine/physics-rapier2d": "workspace:*",
-        "@esengine/build-config": "workspace:*",
-        "rimraf": "^5.0.0",
-        "tsup": "^8.0.0",
-        "typescript": "^5.8.3"
-    },
-    "dependencies": {
-        "tslib": "^2.8.1"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/esengine/esengine.git",
-        "directory": "packages/tilemap"
+  "name": "@esengine/tilemap",
+  "version": "1.0.0",
+  "description": "Tilemap system for ECS Framework - supports Tiled editor import",
+  "esengine": {
+    "plugin": true,
+    "pluginExport": "TilemapPlugin",
+    "category": "tilemap"
+  },
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
     }
+  },
+  "files": [
+    "dist"
+  ],
+  "keywords": [
+    "ecs",
+    "tilemap",
+    "tiled",
+    "game-engine",
+    "2d",
+    "typescript"
+  ],
+  "scripts": {
+    "clean": "rimraf dist tsconfig.tsbuildinfo",
+    "build": "tsup",
+    "build:watch": "tsup --watch",
+    "type-check": "tsc --noEmit",
+    "rebuild": "npm run clean && npm run build"
+  },
+  "author": "yhh",
+  "license": "MIT",
+  "devDependencies": {
+    "@esengine/ecs-framework": "workspace:*",
+    "@esengine/ecs-framework-math": "workspace:*",
+    "@esengine/asset-system": "workspace:*",
+    "@esengine/engine-core": "workspace:*",
+    "@esengine/ecs-engine-bindgen": "workspace:*",
+    "@esengine/physics-rapier2d": "workspace:*",
+    "@esengine/build-config": "workspace:*",
+    "rimraf": "^5.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.8.3"
+  },
+  "dependencies": {
+    "tslib": "^2.8.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/esengine/esengine.git",
+    "directory": "packages/tilemap"
+  },
+  "private": true
 }

--- a/packages/streaming/world-streaming/package.json
+++ b/packages/streaming/world-streaming/package.json
@@ -1,39 +1,40 @@
 {
-    "name": "@esengine/world-streaming",
-    "version": "1.0.0",
-    "description": "World streaming and chunk management system for open world games",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "type": "module",
-    "exports": {
-        ".": {
-            "import": "./dist/index.js",
-            "types": "./dist/index.d.ts"
-        }
-    },
-    "scripts": {
-        "build": "tsup",
-        "dev": "tsup --watch"
-    },
-    "dependencies": {
-        "@esengine/ecs-framework": "workspace:*",
-        "@esengine/engine-core": "workspace:*"
-    },
-    "devDependencies": {
-        "tsup": "^8.0.1",
-        "typescript": "^5.3.3"
-    },
-    "peerDependencies": {
-        "@esengine/ecs-framework": "workspace:*",
-        "@esengine/engine-core": "workspace:*"
-    },
-    "keywords": [
-        "ecs",
-        "streaming",
-        "chunk",
-        "open-world"
-    ],
-    "author": "ESEngine",
-    "license": "MIT"
+  "name": "@esengine/world-streaming",
+  "version": "1.0.0",
+  "description": "World streaming and chunk management system for open world games",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch"
+  },
+  "dependencies": {
+    "@esengine/ecs-framework": "workspace:*",
+    "@esengine/engine-core": "workspace:*"
+  },
+  "devDependencies": {
+    "tsup": "^8.0.1",
+    "typescript": "^5.3.3"
+  },
+  "peerDependencies": {
+    "@esengine/ecs-framework": "workspace:*",
+    "@esengine/engine-core": "workspace:*"
+  },
+  "keywords": [
+    "ecs",
+    "streaming",
+    "chunk",
+    "open-world"
+  ],
+  "author": "ESEngine",
+  "license": "MIT",
+  "private": true
 }

--- a/packages/tools/sdk/package.json
+++ b/packages/tools/sdk/package.json
@@ -1,53 +1,54 @@
 {
-    "name": "@esengine/sdk",
-    "version": "1.0.0",
-    "description": "Unified SDK entry point for ESEngine - single import for all engine modules",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "type": "module",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "import": "./dist/index.js"
-        }
-    },
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsup",
-        "build:watch": "tsup --watch",
-        "type-check": "tsc --noEmit",
-        "clean": "rimraf dist"
-    },
-    "dependencies": {
-        "@esengine/ecs-framework": "workspace:*",
-        "@esengine/engine-core": "workspace:*",
-        "@esengine/ecs-framework-math": "workspace:*",
-        "@esengine/sprite": "workspace:*",
-        "@esengine/fairygui": "workspace:*",
-        "@esengine/audio": "workspace:*",
-        "@esengine/camera": "workspace:*",
-        "@esengine/particle": "workspace:*",
-        "@esengine/physics-rapier2d": "workspace:*",
-        "@esengine/tilemap": "workspace:*",
-        "@esengine/behavior-tree": "workspace:*",
-        "@esengine/asset-system": "workspace:*"
-    },
-    "devDependencies": {
-        "@esengine/build-config": "workspace:*",
-        "rimraf": "^5.0.5",
-        "tsup": "^8.0.0",
-        "typescript": "^5.3.3"
-    },
-    "keywords": [
-        "esengine",
-        "sdk",
-        "ecs",
-        "game-engine",
-        "unified-api"
-    ],
-    "author": "yhh",
-    "license": "MIT"
+  "name": "@esengine/sdk",
+  "version": "1.0.0",
+  "description": "Unified SDK entry point for ESEngine - single import for all engine modules",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "build:watch": "tsup --watch",
+    "type-check": "tsc --noEmit",
+    "clean": "rimraf dist"
+  },
+  "dependencies": {
+    "@esengine/ecs-framework": "workspace:*",
+    "@esengine/engine-core": "workspace:*",
+    "@esengine/ecs-framework-math": "workspace:*",
+    "@esengine/sprite": "workspace:*",
+    "@esengine/fairygui": "workspace:*",
+    "@esengine/audio": "workspace:*",
+    "@esengine/camera": "workspace:*",
+    "@esengine/particle": "workspace:*",
+    "@esengine/physics-rapier2d": "workspace:*",
+    "@esengine/tilemap": "workspace:*",
+    "@esengine/behavior-tree": "workspace:*",
+    "@esengine/asset-system": "workspace:*"
+  },
+  "devDependencies": {
+    "@esengine/build-config": "workspace:*",
+    "rimraf": "^5.0.5",
+    "tsup": "^8.0.0",
+    "typescript": "^5.3.3"
+  },
+  "keywords": [
+    "esengine",
+    "sdk",
+    "ecs",
+    "game-engine",
+    "unified-api"
+  ],
+  "author": "yhh",
+  "license": "MIT",
+  "private": true
 }

--- a/packages/tools/worker-generator/package.json
+++ b/packages/tools/worker-generator/package.json
@@ -52,5 +52,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "private": true
 }


### PR DESCRIPTION
## Problem

Changesets tried to publish `@esengine/platform-web` and potentially other internal packages because they weren't marked as private.

## Solution

Added `"private": true` to 21 packages that shouldn't be published to npm:
- `packages/engine/*` (8 packages)
- `packages/rendering/*` (8 packages)
- `packages/physics/*` (2 packages)
- `packages/streaming/*` (1 package)
- `packages/tools/sdk`, `packages/tools/worker-generator`

## Note

The `ignore` list in changesets config only prevents version bumps, not publishing. `private: true` is needed to prevent npm publish.