### PR TITLE
feat(cli): 增强 Node.js 服务端适配器

### DIFF
--- a/.changeset/cli-server-adapter.md
+++ b/.changeset/cli-server-adapter.md
@@ -1,0 +1,16 @@
+---
+"@esengine/cli": minor
+"@esengine/network-server": patch
+---
+
+feat(cli): 增强 Node.js 服务端适配器
+
+**@esengine/cli:**
+- 添加 @esengine/network-server 依赖支持
+- 生成完整的 ECS 游戏服务器项目结构
+- 组件使用 @ECSComponent 装饰器注册
+- tsconfig 启用 experimentalDecorators
+
+**@esengine/network-server:**
+- 支持 ESM/CJS 双格式导出
+- 添加 ws@8.18.0 解决 Node.js 24 兼容性问题

--- a/packages/network-ext/network-server/package.json
+++ b/packages/network-ext/network-server/package.json
@@ -1,15 +1,21 @@
 {
     "name": "@esengine/network-server",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "TSRPC-based network server for ESEngine",
     "type": "module",
-    "main": "dist/index.js",
+    "main": "dist/index.cjs",
     "module": "dist/index.js",
     "types": "dist/index.d.ts",
     "exports": {
         ".": {
-            "import": "./dist/index.js",
-            "types": "./dist/index.d.ts"
+            "import": {
+                "types": "./dist/index.d.ts",
+                "default": "./dist/index.js"
+            },
+            "require": {
+                "types": "./dist/index.d.cts",
+                "default": "./dist/index.cjs"
+            }
         }
     },
     "files": [
@@ -22,7 +28,8 @@
     },
     "dependencies": {
         "@esengine/network-protocols": "workspace:*",
-        "tsrpc": "^3.4.15"
+        "tsrpc": "^3.4.15",
+        "ws": "^8.18.0"
     },
     "devDependencies": {
         "tsup": "^8.5.1",

--- a/packages/network-ext/network-server/tsup.config.ts
+++ b/packages/network-ext/network-server/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup';
 
 export default defineConfig({
     entry: ['src/index.ts', 'src/main.ts'],
-    format: ['esm'],
+    format: ['esm', 'cjs'],
     dts: true,
     sourcemap: true,
     clean: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1705,6 +1705,9 @@ importers:
       tsrpc:
         specifier: ^3.4.15
         version: 3.4.21
+      ws:
+        specifier: ^8.18.0
+        version: 8.18.3
     devDependencies:
       tsup:
         specifier: ^8.5.1


### PR DESCRIPTION
## Summary
- 增强 CLI 的 Node.js 适配器，支持生成完整的游戏服务端项目
- 修复 network-server 包的 ESM/CJS 双格式支持
- 解决 Node.js 24 与 tsrpc/ws 的兼容性问题

## Changes

### @esengine/cli
- 添加 `@esengine/network-server` 依赖
- 生成完整的 ECS 游戏服务器项目结构（GameServer、Game、Scene、Components、Systems）
- 组件使用 `@ECSComponent` 装饰器注册
- tsconfig 启用 `experimentalDecorators`
- 移除导入路径的 `.js` 扩展名

### @esengine/network-server
- 配置 tsup 同时输出 ESM 和 CJS 格式
- 添加 `ws@8.18.0` 解决 Node.js 24 兼容性问题
- 更新 package.json exports 支持双模块格式

## Test plan
- [x] 服务端启动成功
- [x] ECS Core 初始化正常
- [x] WebSocket 服务器监听正常