### PR TITLE
fix(server): allow define() to be called before start()

### DIFF
--- a/.changeset/fix-room-define-timing.md
+++ b/.changeset/fix-room-define-timing.md
@@ -1,0 +1,13 @@
+---
+"@esengine/server": patch
+---
+
+fix: allow define() to be called before start()
+
+Previously, calling `server.define()` before `server.start()` would throw an error because `roomManager` was initialized inside `start()`. This fix moves the `roomManager` initialization to `createServer()`, allowing the expected usage pattern:
+
+```typescript
+const server = await createServer({ port: 3000 })
+server.define('world', WorldRoom)  // Now works correctly
+await server.start()
+```


### PR DESCRIPTION
## Summary
- Fix bug where `server.define()` threw error when called before `server.start()`
- Move `roomManager` initialization from `start()` to `createServer()`
- Clean up non-null assertions since `roomManager` is always defined

## Problem
Previously, the expected usage pattern would fail:
```typescript
const server = await createServer({ port: 3000 })
server.define('world', WorldRoom)  // Error: Server not started
await server.start()
```

## Solution
Initialize `roomManager` in `createServer()` instead of `start()`. The send callback uses optional chaining so it safely does nothing if `rpcServer` is not yet started.

## Test plan
- [x] Build succeeds
- [ ] CardOpenWorld server starts without error