### PR TITLE
fix(server): expose id property on ServerConnection type

### DIFF
--- a/.changeset/fix-server-connection-id-type.md
+++ b/.changeset/fix-server-connection-id-type.md
@@ -1,0 +1,7 @@
+---
+"@esengine/server": patch
+---
+
+fix: expose `id` property on ServerConnection type
+
+TypeScript was not properly resolving the inherited `id` property from the base `Connection` interface in some module resolution scenarios. This fix explicitly declares the `id` property on `ServerConnection` to ensure it's always visible to consumers.

--- a/packages/framework/server/src/types/index.ts
+++ b/packages/framework/server/src/types/index.ts
@@ -71,6 +71,12 @@ export interface ServerConfig {
  */
 export interface ServerConnection<TData = Record<string, unknown>> extends Connection<TData> {
     /**
+     * @zh 连接唯一标识（继承自 Connection）
+     * @en Connection unique identifier (inherited from Connection)
+     */
+    readonly id: string
+
+    /**
      * @zh 用户自定义数据
      * @en User-defined data
      */


### PR DESCRIPTION
## Summary
- Explicitly declare `id` property on `ServerConnection` interface
- Fixes TypeScript type resolution issue where inherited `id` from `Connection` was not visible

## Problem
When using `@esengine/server` in projects, the `conn.id` property was not recognized by TypeScript:
```typescript
onConnect(conn) {
    console.log(conn.id)  // Error: Property 'id' does not exist on type 'ServerConnection'
}
```

## Solution
Explicitly declare the `id` property in `ServerConnection` interface. The property is already inherited from `Connection`, but some module resolution scenarios fail to pick it up.

## Test plan
- [x] Build succeeds
- [ ] CardOpenWorld server builds without type errors