### PR TITLE
feat(rpc): export RpcClient from main entry point

### DIFF
--- a/.changeset/rpc-export-client.md
+++ b/.changeset/rpc-export-client.md
@@ -1,0 +1,15 @@
+---
+"@esengine/rpc": patch
+---
+
+feat: export RpcClient and connect from main entry point
+
+Re-export `RpcClient`, `connect`, and related types from the main entry point for better compatibility with bundlers (Cocos Creator, Vite, etc.) that may have issues with subpath exports.
+
+```typescript
+// Now works in all environments:
+import { rpc, RpcClient, connect } from '@esengine/rpc';
+
+// Subpath import still supported:
+import { RpcClient } from '@esengine/rpc/client';
+```

--- a/packages/framework/rpc/src/index.ts
+++ b/packages/framework/rpc/src/index.ts
@@ -40,3 +40,7 @@
 
 export { rpc } from './define'
 export * from './types'
+
+// Re-export client for browser/bundler compatibility
+export { RpcClient, connect } from './client/index'
+export type { RpcClientOptions, WebSocketAdapter, WebSocketFactory } from './client/index'


### PR DESCRIPTION
## Summary
- Export `RpcClient`, `connect`, and related types from main entry point
- Improves compatibility with bundlers that have issues with subpath exports

## Problem
Cocos Creator and some other bundlers don't properly handle ESM subpath exports like:
```typescript
import { RpcClient } from '@esengine/rpc/client';  // May fail in some bundlers
```

## Solution
Re-export client-side types from main entry:
```typescript
import { rpc, RpcClient, connect } from '@esengine/rpc';  // Works everywhere
```

Subpath imports still work for environments that support them.