### PR TITLE
fix(ecs): COMPONENT_ADDED 事件添加 entity 字段

### DIFF
--- a/.changeset/fix-component-added-entity.md
+++ b/.changeset/fix-component-added-entity.md
@@ -1,0 +1,7 @@
+---
+"@esengine/ecs-framework": patch
+---
+
+fix(ecs): COMPONENT_ADDED 事件添加 entity 字段
+
+修复 `ECSEventType.COMPONENT_ADDED` 事件缺少 `entity` 字段的问题，导致 ECSRoom 的 `@NetworkEntity` 自动广播功能报错。

--- a/packages/framework/core/src/ECS/Entity.ts
+++ b/packages/framework/core/src/ECS/Entity.ts
@@ -478,6 +478,7 @@ export class Entity {
             this.scene.eventSystem.emitSync(ECSEventType.COMPONENT_ADDED, {
                 timestamp: Date.now(),
                 source: 'Entity',
+                entity: this,
                 entityId: this.id,
                 entityName: this.name,
                 entityTag: this.tag?.toString(),


### PR DESCRIPTION
## Summary
- 修复 `COMPONENT_ADDED` 事件缺少 `entity` 字段
- 导致 ECSRoom 的 `@NetworkEntity` 自动广播报错

## 问题
```
TypeError: Cannot read properties of undefined (reading 'id')
```

## 修复
在事件 payload 中添加 `entity: this` 字段