### PR TITLE
feat(ecs): 添加运行时环境区分机制 | add runtime environment detection

### DIFF
--- a/.changeset/add-runtime-environment.md
+++ b/.changeset/add-runtime-environment.md
@@ -1,0 +1,36 @@
+---
+"@esengine/ecs-framework": minor
+---
+
+feat(ecs): 添加运行时环境区分机制 | add runtime environment detection
+
+新增功能：
+- `Core` 新增静态属性 `runtimeEnvironment`，支持 `'server' | 'client' | 'standalone'`
+- `Core` 新增 `isServer` / `isClient` 静态只读属性
+- `ICoreConfig` 新增 `runtimeEnvironment` 配置项
+- `Scene` 新增 `isServer` / `isClient` 只读属性（默认从 Core 继承，可通过 config 覆盖）
+- 新增 `@ServerOnly()` / `@ClientOnly()` / `@NotServer()` / `@NotClient()` 方法装饰器
+
+用于网络游戏中区分服务端权威逻辑和客户端逻辑：
+
+```typescript
+// 方式1: 全局设置（推荐）
+Core.create({ runtimeEnvironment: 'server' });
+// 或直接设置静态属性
+Core.runtimeEnvironment = 'server';
+
+// 所有场景自动继承
+const scene = new Scene();
+console.log(scene.isServer); // true
+
+// 方式2: 单个场景覆盖（可选）
+const clientScene = new Scene({ runtimeEnvironment: 'client' });
+
+// 在系统中检查环境
+class CollectibleSpawnSystem extends EntitySystem {
+    private checkCollections(): void {
+        if (!this.scene.isServer) return; // 客户端跳过
+        // ... 服务端权威逻辑
+    }
+}
+```

--- a/docs/src/content/docs/en/guide/scene/index.md
+++ b/docs/src/content/docs/en/guide/scene/index.md
@@ -71,6 +71,55 @@ class ConfiguredScene extends Scene {
 }
 ```
 
+## Runtime Environment
+
+For networked games, you can configure the runtime environment to distinguish between server and client logic.
+
+### Global Configuration (Recommended)
+
+Set the runtime environment once at the Core level - all Scenes will inherit this setting:
+
+```typescript
+import { Core } from '@esengine/ecs-framework';
+
+// Method 1: Set in Core.create()
+Core.create({ runtimeEnvironment: 'server' });
+
+// Method 2: Set static property directly
+Core.runtimeEnvironment = 'server';
+```
+
+### Per-Scene Override
+
+Individual scenes can override the global setting:
+
+```typescript
+const clientScene = new Scene({ runtimeEnvironment: 'client' });
+```
+
+### Environment Types
+
+| Environment | Use Case |
+|-------------|----------|
+| `'standalone'` | Single-player games (default) |
+| `'server'` | Game server, authoritative logic |
+| `'client'` | Game client, rendering/input |
+
+### Checking Environment in Systems
+
+```typescript
+class CollectibleSpawnSystem extends EntitySystem {
+  private checkCollections(): void {
+    // Skip on client - only server handles authoritative logic
+    if (!this.scene.isServer) return;
+
+    // Server-authoritative spawn logic...
+  }
+}
+```
+
+See [System Runtime Decorators](/en/guide/system/index#runtime-environment-decorators) for decorator-based approach.
+
 ### Running a Scene
 
 ```typescript

--- a/docs/src/content/docs/en/guide/system/index.md
+++ b/docs/src/content/docs/en/guide/system/index.md
@@ -160,6 +160,53 @@ scene.addSystem(new SystemA()); // addOrder = 0, executes first
 scene.addSystem(new SystemB()); // addOrder = 1, executes second
 ```
 
+## Runtime Environment Decorators
+
+For networked games, you can use decorators to control which environment a system method runs in.
+
+### Available Decorators
+
+| Decorator | Effect |
+|-----------|--------|
+| `@ServerOnly()` | Method only executes on server |
+| `@ClientOnly()` | Method only executes on client |
+| `@NotServer()` | Method skipped on server |
+| `@NotClient()` | Method skipped on client |
+
+### Usage Example
+
+```typescript
+import { EntitySystem, ServerOnly, ClientOnly } from '@esengine/ecs-framework';
+
+class GameSystem extends EntitySystem {
+  @ServerOnly()
+  private spawnEnemies(): void {
+    // Only runs on server - authoritative spawn logic
+  }
+
+  @ClientOnly()
+  private playEffects(): void {
+    // Only runs on client - visual effects
+  }
+}
+```
+
+### Simple Conditional Check
+
+For simple cases, a direct check is often clearer than decorators:
+
+```typescript
+class CollectibleSystem extends EntitySystem {
+  private checkCollections(): void {
+    if (!this.scene.isServer) return;  // Skip on client
+
+    // Server-authoritative logic...
+  }
+}
+```
+
+See [Scene Runtime Environment](/en/guide/scene/index#runtime-environment) for configuration details.
+
 ## Next Steps
 
 - [System Types](/en/guide/system/types) - Learn about different system base classes

--- a/docs/src/content/docs/guide/scene/index.md
+++ b/docs/src/content/docs/guide/scene/index.md
@@ -71,6 +71,55 @@ class ConfiguredScene extends Scene {
 }
 ```
 
+## 运行时环境
+
+对于网络游戏，你可以配置运行时环境来区分服务端和客户端逻辑。
+
+### 全局配置（推荐）
+
+在 Core 层级设置一次运行时环境，所有场景都会继承此设置：
+
+```typescript
+import { Core } from '@esengine/ecs-framework';
+
+// 方式1：在 Core.create() 中设置
+Core.create({ runtimeEnvironment: 'server' });
+
+// 方式2：直接设置静态属性
+Core.runtimeEnvironment = 'server';
+```
+
+### 单个场景覆盖
+
+个别场景可以覆盖全局设置：
+
+```typescript
+const clientScene = new Scene({ runtimeEnvironment: 'client' });
+```
+
+### 环境类型
+
+| 环境 | 使用场景 |
+|------|----------|
+| `'standalone'` | 单机游戏（默认） |
+| `'server'` | 游戏服务器，权威逻辑 |
+| `'client'` | 游戏客户端，渲染/输入 |
+
+### 在系统中检查环境
+
+```typescript
+class CollectibleSpawnSystem extends EntitySystem {
+  private checkCollections(): void {
+    // 客户端跳过 - 只有服务端处理权威逻辑
+    if (!this.scene.isServer) return;
+
+    // 服务端权威生成逻辑...
+  }
+}
+```
+
+参见 [系统运行时装饰器](/guide/system/index#运行时环境装饰器) 了解基于装饰器的方式。
+
 ### 运行场景
 
 ```typescript

--- a/docs/src/content/docs/guide/system/index.md
+++ b/docs/src/content/docs/guide/system/index.md
@@ -160,6 +160,53 @@ scene.addSystem(new SystemA()); // addOrder = 0，先执行
 scene.addSystem(new SystemB()); // addOrder = 1，后执行
 ```
 
+## 运行时环境装饰器
+
+对于网络游戏，你可以使用装饰器来控制系统方法在哪个环境下执行。
+
+### 可用装饰器
+
+| 装饰器 | 效果 |
+|--------|------|
+| `@ServerOnly()` | 方法仅在服务端执行 |
+| `@ClientOnly()` | 方法仅在客户端执行 |
+| `@NotServer()` | 方法在服务端跳过 |
+| `@NotClient()` | 方法在客户端跳过 |
+
+### 使用示例
+
+```typescript
+import { EntitySystem, ServerOnly, ClientOnly } from '@esengine/ecs-framework';
+
+class GameSystem extends EntitySystem {
+  @ServerOnly()
+  private spawnEnemies(): void {
+    // 仅在服务端运行 - 权威生成逻辑
+  }
+
+  @ClientOnly()
+  private playEffects(): void {
+    // 仅在客户端运行 - 视觉效果
+  }
+}
+```
+
+### 简单条件检查
+
+对于简单场景，直接检查通常比装饰器更清晰：
+
+```typescript
+class CollectibleSystem extends EntitySystem {
+  private checkCollections(): void {
+    if (!this.scene.isServer) return;  // 客户端跳过
+
+    // 服务端权威逻辑...
+  }
+}
+```
+
+参见 [场景运行时环境](/guide/scene/index#运行时环境) 了解配置详情。
+
 ## 下一步
 
 - [系统类型](/guide/system/types) - 了解不同类型的系统基类

--- a/packages/framework/core/src/Core.ts
+++ b/packages/framework/core/src/Core.ts
@@ -5,7 +5,7 @@ import { Time } from './Utils/Time';
 import { PerformanceMonitor } from './Utils/PerformanceMonitor';
 import { PoolManager } from './Utils/Pool/PoolManager';
 import { DebugManager } from './Utils/Debug';
-import { ICoreConfig, IECSDebugConfig } from './Types';
+import { ICoreConfig, IECSDebugConfig, RuntimeEnvironment } from './Types';
 import { createLogger } from './Utils/Logger';
 import { SceneManager } from './ECS/SceneManager';
 import { IScene } from './ECS/IScene';
@@ -62,6 +62,47 @@ export class Core {
      * @en Game paused state, when set to true, game loop will pause execution
      */
     public static paused = false;
+
+    /**
+     * @zh 运行时环境
+     * @en Runtime environment
+     *
+     * @zh 全局运行时环境设置。所有 Scene 默认继承此值。
+     * 服务端框架（如 @esengine/server）应在启动时设置为 'server'。
+     * 客户端应用应设置为 'client'。
+     * 单机游戏使用默认值 'standalone'。
+     *
+     * @en Global runtime environment setting. All Scenes inherit this value by default.
+     * Server frameworks (like @esengine/server) should set this to 'server' at startup.
+     * Client apps should set this to 'client'.
+     * Standalone games use the default 'standalone'.
+     *
+     * @example
+     * ```typescript
+     * // @zh 服务端启动时设置 | @en Set at server startup
+     * Core.runtimeEnvironment = 'server';
+     *
+     * // @zh 或在 Core.create 时配置 | @en Or configure in Core.create
+     * Core.create({ runtimeEnvironment: 'server' });
+     * ```
+     */
+    public static runtimeEnvironment: RuntimeEnvironment = 'standalone';
+
+    /**
+     * @zh 是否在服务端运行
+     * @en Whether running on server
+     */
+    public static get isServer(): boolean {
+        return Core.runtimeEnvironment === 'server';
+    }
+
+    /**
+     * @zh 是否在客户端运行
+     * @en Whether running on client
+     */
+    public static get isClient(): boolean {
+        return Core.runtimeEnvironment === 'client';
+    }
 
     /**
      * @zh 全局核心实例，可能为null表示Core尚未初始化或已被销毁
@@ -132,6 +173,11 @@ export class Core {
         Core._instance = this;
         this._config = { debug: true, ...config };
         this._serviceContainer = new ServiceContainer();
+
+        // 设置全局运行时环境
+        if (config.runtimeEnvironment) {
+            Core.runtimeEnvironment = config.runtimeEnvironment;
+        }
 
         this._timerManager = new TimerManager();
         this._serviceContainer.registerInstance(TimerManager, this._timerManager);

--- a/packages/framework/core/src/ECS/Decorators/RuntimeEnvironment.ts
+++ b/packages/framework/core/src/ECS/Decorators/RuntimeEnvironment.ts
@@ -1,0 +1,188 @@
+/**
+ * @zh 运行时环境装饰器
+ * @en Runtime Environment Decorators
+ *
+ * @zh 提供 @ServerOnly 和 @ClientOnly 装饰器，用于标记只在特定环境执行的方法
+ * @en Provides @ServerOnly and @ClientOnly decorators to mark methods that only execute in specific environments
+ */
+
+import type { EntitySystem } from '../Systems/EntitySystem';
+
+/**
+ * @zh 服务端专用方法装饰器
+ * @en Server-only method decorator
+ *
+ * @zh 被装饰的方法只会在服务端环境执行（scene.isServer === true）。
+ * 在客户端或单机模式下，方法调用会被静默跳过。
+ *
+ * @en Decorated methods only execute in server environment (scene.isServer === true).
+ * In client or standalone mode, method calls are silently skipped.
+ *
+ * @example
+ * ```typescript
+ * class CollectibleSpawnSystem extends EntitySystem {
+ *     @ServerOnly()
+ *     private checkCollections(players: readonly Entity[]): void {
+ *         // 只在服务端执行收集检测
+ *         // Only check collections on server
+ *         for (const entity of this.scene.entities.buffer) {
+ *             // ...
+ *         }
+ *     }
+ * }
+ * ```
+ */
+export function ServerOnly(): MethodDecorator {
+    return function <T>(
+        _target: object,
+        _propertyKey: string | symbol,
+        descriptor: TypedPropertyDescriptor<T>
+    ): TypedPropertyDescriptor<T> | void {
+        const originalMethod = descriptor.value as unknown as (...args: unknown[]) => unknown;
+
+        if (typeof originalMethod !== 'function') {
+            throw new Error(`@ServerOnly can only be applied to methods, not ${typeof originalMethod}`);
+        }
+
+        descriptor.value = function (this: EntitySystem, ...args: unknown[]): unknown {
+            if (!this.scene?.isServer) {
+                return undefined;
+            }
+            return originalMethod.apply(this, args);
+        } as unknown as T;
+
+        return descriptor;
+    };
+}
+
+/**
+ * @zh 客户端专用方法装饰器
+ * @en Client-only method decorator
+ *
+ * @zh 被装饰的方法只会在客户端环境执行（scene.isClient === true）。
+ * 在服务端或单机模式下，方法调用会被静默跳过。
+ *
+ * @en Decorated methods only execute in client environment (scene.isClient === true).
+ * In server or standalone mode, method calls are silently skipped.
+ *
+ * @example
+ * ```typescript
+ * class RenderSystem extends EntitySystem {
+ *     @ClientOnly()
+ *     private updateVisuals(): void {
+ *         // 只在客户端执行渲染逻辑
+ *         // Only update visuals on client
+ *     }
+ * }
+ * ```
+ */
+export function ClientOnly(): MethodDecorator {
+    return function <T>(
+        _target: object,
+        _propertyKey: string | symbol,
+        descriptor: TypedPropertyDescriptor<T>
+    ): TypedPropertyDescriptor<T> | void {
+        const originalMethod = descriptor.value as unknown as (...args: unknown[]) => unknown;
+
+        if (typeof originalMethod !== 'function') {
+            throw new Error(`@ClientOnly can only be applied to methods, not ${typeof originalMethod}`);
+        }
+
+        descriptor.value = function (this: EntitySystem, ...args: unknown[]): unknown {
+            if (!this.scene?.isClient) {
+                return undefined;
+            }
+            return originalMethod.apply(this, args);
+        } as unknown as T;
+
+        return descriptor;
+    };
+}
+
+/**
+ * @zh 非客户端环境方法装饰器
+ * @en Non-client method decorator
+ *
+ * @zh 被装饰的方法在服务端和单机模式下执行，但不在客户端执行。
+ * 用于需要在服务端和单机都运行，但客户端跳过的逻辑。
+ *
+ * @en Decorated methods execute in server and standalone mode, but not on client.
+ * Used for logic that should run on server and standalone, but skip on client.
+ *
+ * @example
+ * ```typescript
+ * class SpawnSystem extends EntitySystem {
+ *     @NotClient()
+ *     private spawnEntities(): void {
+ *         // 服务端和单机模式执行，客户端跳过
+ *         // Execute on server and standalone, skip on client
+ *     }
+ * }
+ * ```
+ */
+export function NotClient(): MethodDecorator {
+    return function <T>(
+        _target: object,
+        _propertyKey: string | symbol,
+        descriptor: TypedPropertyDescriptor<T>
+    ): TypedPropertyDescriptor<T> | void {
+        const originalMethod = descriptor.value as unknown as (...args: unknown[]) => unknown;
+
+        if (typeof originalMethod !== 'function') {
+            throw new Error(`@NotClient can only be applied to methods, not ${typeof originalMethod}`);
+        }
+
+        descriptor.value = function (this: EntitySystem, ...args: unknown[]): unknown {
+            if (this.scene?.isClient) {
+                return undefined;
+            }
+            return originalMethod.apply(this, args);
+        } as unknown as T;
+
+        return descriptor;
+    };
+}
+
+/**
+ * @zh 非服务端环境方法装饰器
+ * @en Non-server method decorator
+ *
+ * @zh 被装饰的方法在客户端和单机模式下执行，但不在服务端执行。
+ * 用于需要在客户端和单机都运行，但服务端跳过的逻辑（如渲染、音效）。
+ *
+ * @en Decorated methods execute in client and standalone mode, but not on server.
+ * Used for logic that should run on client and standalone, but skip on server (like rendering, audio).
+ *
+ * @example
+ * ```typescript
+ * class AudioSystem extends EntitySystem {
+ *     @NotServer()
+ *     private playSound(): void {
+ *         // 客户端和单机模式执行，服务端跳过
+ *         // Execute on client and standalone, skip on server
+ *     }
+ * }
+ * ```
+ */
+export function NotServer(): MethodDecorator {
+    return function <T>(
+        _target: object,
+        _propertyKey: string | symbol,
+        descriptor: TypedPropertyDescriptor<T>
+    ): TypedPropertyDescriptor<T> | void {
+        const originalMethod = descriptor.value as unknown as (...args: unknown[]) => unknown;
+
+        if (typeof originalMethod !== 'function') {
+            throw new Error(`@NotServer can only be applied to methods, not ${typeof originalMethod}`);
+        }
+
+        descriptor.value = function (this: EntitySystem, ...args: unknown[]): unknown {
+            if (this.scene?.isServer) {
+                return undefined;
+            }
+            return originalMethod.apply(this, args);
+        } as unknown as T;
+
+        return descriptor;
+    };
+}

--- a/packages/framework/core/src/ECS/Decorators/index.ts
+++ b/packages/framework/core/src/ECS/Decorators/index.ts
@@ -82,3 +82,14 @@ export {
     hasSchedulingMetadata,
     SCHEDULING_METADATA
 } from './SystemScheduling';
+
+// ============================================================================
+// Runtime Environment Decorators
+// 运行时环境装饰器
+// ============================================================================
+export {
+    ServerOnly,
+    ClientOnly,
+    NotServer,
+    NotClient
+} from './RuntimeEnvironment';

--- a/packages/framework/core/src/ECS/IScene.ts
+++ b/packages/framework/core/src/ECS/IScene.ts
@@ -12,6 +12,10 @@ import type { ServiceContainer, ServiceType } from '../Core/ServiceContainer';
 import type { TypedQueryBuilder } from './Core/Query/TypedQuery';
 import type { SceneSerializationOptions, SceneDeserializationOptions } from './Serialization/SceneSerializer';
 import type { IncrementalSnapshot, IncrementalSerializationOptions } from './Serialization/IncrementalSerializer';
+import type { RuntimeEnvironment } from '../Types';
+
+// Re-export for convenience
+export type { RuntimeEnvironment };
 
 /**
  * 场景接口定义
@@ -112,6 +116,27 @@ export type IScene = {
      * until begin() is called to start running the scene.
      */
     isEditorMode: boolean;
+
+    /**
+     * @zh 运行时环境
+     * @en Runtime environment
+     *
+     * @zh 标识场景运行在服务端、客户端还是单机模式
+     * @en Indicates whether scene runs on server, client, or standalone mode
+     */
+    readonly runtimeEnvironment: RuntimeEnvironment;
+
+    /**
+     * @zh 是否在服务端运行
+     * @en Whether running on server
+     */
+    readonly isServer: boolean;
+
+    /**
+     * @zh 是否在客户端运行
+     * @en Whether running on client
+     */
+    readonly isClient: boolean;
 
     /**
      * 获取系统列表
@@ -395,4 +420,18 @@ export type ISceneConfig = {
      * @default 10
      */
     maxSystemErrorCount?: number;
+
+    /**
+     * @zh 运行时环境
+     * @en Runtime environment
+     *
+     * @zh 用于区分场景运行在服务端、客户端还是单机模式。
+     * 配合 @ServerOnly / @ClientOnly 装饰器使用，可以让系统方法只在特定环境执行。
+     *
+     * @en Used to distinguish whether scene runs on server, client, or standalone mode.
+     * Works with @ServerOnly / @ClientOnly decorators to make system methods execute only in specific environments.
+     *
+     * @default 'standalone'
+     */
+    runtimeEnvironment?: RuntimeEnvironment;
 }

--- a/packages/framework/core/src/ECS/index.ts
+++ b/packages/framework/core/src/ECS/index.ts
@@ -7,7 +7,7 @@ export * from './Utils';
 export * from './Decorators';
 export * from './Components';
 export { Scene } from './Scene';
-export type { IScene, ISceneFactory, ISceneConfig } from './IScene';
+export type { IScene, ISceneFactory, ISceneConfig, RuntimeEnvironment } from './IScene';
 export { SceneManager } from './SceneManager';
 export { World } from './World';
 export type { IWorldConfig } from './World';

--- a/packages/framework/core/src/Types/index.ts
+++ b/packages/framework/core/src/Types/index.ts
@@ -268,6 +268,12 @@ export type IECSDebugConfig = {
 }
 
 /**
+ * @zh 运行时环境类型
+ * @en Runtime environment type
+ */
+export type RuntimeEnvironment = 'server' | 'client' | 'standalone';
+
+/**
  * Core配置接口
  */
 export type ICoreConfig = {
@@ -277,6 +283,16 @@ export type ICoreConfig = {
     debugConfig?: IECSDebugConfig;
     /** WorldManager配置 */
     worldManagerConfig?: IWorldManagerConfig;
+    /**
+     * @zh 运行时环境
+     * @en Runtime environment
+     *
+     * @zh 设置后所有 Scene 默认继承此环境。服务端框架应设置为 'server'，客户端应用设置为 'client'。
+     * @en All Scenes inherit this environment by default. Server frameworks should set 'server', client apps should set 'client'.
+     *
+     * @default 'standalone'
+     */
+    runtimeEnvironment?: RuntimeEnvironment;
 }
 
 /**


### PR DESCRIPTION
## Summary

- `Core` 新增静态属性 `runtimeEnvironment`，支持 `'server' | 'client' | 'standalone'`
- `Core` 新增 `isServer` / `isClient` 静态只读属性
- `ICoreConfig` 新增 `runtimeEnvironment` 配置项
- `Scene` 新增 `isServer` / `isClient` 只读属性（默认从 Core 继承，可通过 config 覆盖）
- 新增 `@ServerOnly()` / `@ClientOnly()` / `@NotServer()` / `@NotClient()` 方法装饰器
- 更新中英文文档

## Usage

```typescript
// 全局设置（推荐）
Core.create({ runtimeEnvironment: 'server' });

// 在系统中检查环境
class CollectibleSpawnSystem extends EntitySystem {
  private checkCollections(): void {
    if (!this.scene.isServer) return; // 客户端跳过
    // 服务端权威逻辑...
  }
}
```

## Test plan

- [x] 构建通过
- [x] 类型检查通过
- [x] 文档已更新