### PR TITLE
fix(behavior-tree): export NodeExecutorMetadata as value instead of type

### DIFF
--- a/.changeset/fix-behavior-tree-decorator-export.md
+++ b/.changeset/fix-behavior-tree-decorator-export.md
@@ -1,0 +1,12 @@
+---
+"@esengine/behavior-tree": patch
+---
+
+fix(behavior-tree): export NodeExecutorMetadata as value instead of type
+
+Fixed the export of `NodeExecutorMetadata` decorator in `execution/index.ts`.
+Previously it was exported as `export type { NodeExecutorMetadata }` which only
+exported the type signature, not the actual function. This caused runtime errors
+in Cocos Creator: "TypeError: (intermediate value) is not a function".
+
+Changed to `export { NodeExecutorMetadata }` to properly export the decorator function.

--- a/packages/framework/behavior-tree/src/execution/index.ts
+++ b/packages/framework/behavior-tree/src/execution/index.ts
@@ -5,7 +5,7 @@ export { BehaviorTreeAssetManager } from './BehaviorTreeAssetManager';
 export type { INodeExecutor, NodeExecutionContext } from './NodeExecutor';
 export { NodeExecutorRegistry, BindingHelper } from './NodeExecutor';
 export { BehaviorTreeExecutionSystem } from './BehaviorTreeExecutionSystem';
-export type { NodeMetadata, ConfigFieldDefinition, NodeExecutorMetadata } from './NodeMetadata';
-export { NodeMetadataRegistry } from './NodeMetadata';
+export type { NodeMetadata, ConfigFieldDefinition } from './NodeMetadata';
+export { NodeMetadataRegistry, NodeExecutorMetadata } from './NodeMetadata';
 
 export * from './Executors';


### PR DESCRIPTION
## Summary
- Fixed `NodeExecutorMetadata` decorator export in `execution/index.ts`
- Changed from `export type { NodeExecutorMetadata }` to `export { NodeExecutorMetadata }`

## Problem
In Cocos Creator, using `@NodeExecutorMetadata` decorator caused runtime error:
```
TypeError: (intermediate value)(intermediate value)(intermediate value) is not a function
```

This happened because `NodeExecutorMetadata` was exported as a **type** only, not as the actual function value.

## Solution
Export `NodeExecutorMetadata` as a value export so the decorator function is available at runtime.

## Test
Tested in lawn-mower-demo with Cocos Creator - decorator now works correctly.