### PR TITLE
feat(behavior-tree): add action() and condition() methods to BehaviorTreeBuilder

### DIFF
--- a/.changeset/behavior-tree-builder-action.md
+++ b/.changeset/behavior-tree-builder-action.md
@@ -1,0 +1,35 @@
+---
+"@esengine/behavior-tree": minor
+---
+
+feat: add action() and condition() methods to BehaviorTreeBuilder
+
+Added new methods to support custom executor types directly in the builder:
+
+- `action(implementationType, name?, config?)` - Use custom action executors registered via `@NodeExecutorMetadata`
+- `condition(implementationType, name?, config?)` - Use custom condition executors
+
+This provides a cleaner API for using custom node executors compared to the existing `executeAction()` which only supports blackboard functions.
+
+Example:
+```typescript
+// Define custom executor
+@NodeExecutorMetadata({
+    implementationType: 'AttackAction',
+    nodeType: NodeType.Action,
+    displayName: 'Attack',
+    category: 'Combat'
+})
+class AttackAction implements INodeExecutor {
+    execute(context: NodeExecutionContext): TaskStatus {
+        return TaskStatus.Success;
+    }
+}
+
+// Use in builder
+const tree = BehaviorTreeBuilder.create('AI')
+    .selector('Root')
+        .action('AttackAction', 'Attack', { damage: 50 })
+    .end()
+    .build();
+```

--- a/packages/framework/behavior-tree/package.json
+++ b/packages/framework/behavior-tree/package.json
@@ -29,7 +29,8 @@
         "clean": "rimraf dist tsconfig.tsbuildinfo",
         "build": "tsup",
         "build:watch": "tsup --watch",
-        "type-check": "tsc --noEmit"
+        "type-check": "tsc --noEmit",
+        "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
     },
     "author": "yhh",
     "license": "MIT",

--- a/packages/framework/behavior-tree/src/BehaviorTreeBuilder.ts
+++ b/packages/framework/behavior-tree/src/BehaviorTreeBuilder.ts
@@ -181,10 +181,71 @@ export class BehaviorTreeBuilder {
     }
 
     /**
-     * 添加执行动作
+     * 添加执行动作（通过黑板函数）
+     *
+     * @zh 使用黑板中的 action_{actionName} 函数执行动作
+     * @en Execute action using action_{actionName} function from blackboard
+     *
+     * @example
+     * ```typescript
+     * BehaviorTreeBuilder.create("AI")
+     *     .defineBlackboardVariable("action_Attack", (entity) => TaskStatus.Success)
+     *     .selector("Root")
+     *         .executeAction("Attack")
+     *     .end()
+     *     .build();
+     * ```
      */
     executeAction(actionName: string, name?: string): BehaviorTreeBuilder {
         return this.addActionNode('ExecuteAction', name || 'ExecuteAction', { actionName });
+    }
+
+    /**
+     * 添加自定义动作节点
+     *
+     * @zh 直接使用注册的执行器类型（通过 @NodeExecutorMetadata 装饰器注册的类）
+     * @en Use a registered executor type directly (class registered via @NodeExecutorMetadata decorator)
+     *
+     * @param implementationType - 执行器类型名称（@NodeExecutorMetadata 中的 implementationType）
+     * @param name - 节点显示名称
+     * @param config - 节点配置参数
+     *
+     * @example
+     * ```typescript
+     * // 1. 定义自定义执行器
+     * @NodeExecutorMetadata({
+     *     implementationType: 'AttackAction',
+     *     nodeType: NodeType.Action,
+     *     displayName: '攻击动作',
+     *     category: 'Action'
+     * })
+     * class AttackAction implements INodeExecutor {
+     *     execute(context: NodeExecutionContext): TaskStatus {
+     *         console.log("执行攻击！");
+     *         return TaskStatus.Success;
+     *     }
+     * }
+     *
+     * // 2. 在行为树中使用
+     * BehaviorTreeBuilder.create("AI")
+     *     .selector("Root")
+     *         .action("AttackAction", "Attack")
+     *     .end()
+     *     .build();
+     * ```
+     */
+    action(implementationType: string, name?: string, config?: Record<string, any>): BehaviorTreeBuilder {
+        return this.addActionNode(implementationType, name || implementationType, config || {});
+    }
+
+    /**
+     * 添加自定义条件节点
+     *
+     * @zh 直接使用注册的条件执行器类型
+     * @en Use a registered condition executor type directly
+     */
+    condition(implementationType: string, name?: string, config?: Record<string, any>): BehaviorTreeBuilder {
+        return this.addConditionNode(implementationType, name || implementationType, config || {});
     }
 
     /**


### PR DESCRIPTION
## Summary
- Add `action(implementationType, name?, config?)` method for using custom action executors
- Add `condition(implementationType, name?, config?)` method for using custom condition executors
- Update documentation (EN and CN) with usage examples and method comparison table

## Changes
- `packages/framework/behavior-tree/src/BehaviorTreeBuilder.ts` - Add new methods
- `docs/src/content/docs/en/modules/behavior-tree/custom-actions.md` - English docs
- `docs/src/content/docs/modules/behavior-tree/custom-actions.md` - Chinese docs

## Usage

```typescript
// Define custom executor
@NodeExecutorMetadata({
    implementationType: 'AttackAction',
    nodeType: NodeType.Action,
    displayName: 'Attack',
    category: 'Combat'
})
class AttackAction implements INodeExecutor {
    execute(context: NodeExecutionContext): TaskStatus {
        return TaskStatus.Success;
    }
}

// Use in builder with new action() method
const tree = BehaviorTreeBuilder.create('AI')
    .selector('Root')
        .action('AttackAction', 'Attack', { damage: 50 })
    .end()
    .build();
```

## Method Comparison
| Method | Description |
|--------|-------------|
| `.action(type, name?, config?)` | Use custom action executor class |
| `.condition(type, name?, config?)` | Use custom condition executor class |
| `.executeAction(name)` | Use blackboard function `action_{name}` |

## Test plan
- [x] Unit tests passed
- [x] Build passed
- [x] Documentation updated