### PR TITLE
fix(node-editor): enable npm publishing

### DIFF
--- a/.github/workflows/release-changesets.yml
+++ b/.github/workflows/release-changesets.yml
@@ -62,6 +62,7 @@ jobs:
           pnpm --filter "@esengine/transaction" build
           pnpm --filter "@esengine/cli" build
           pnpm --filter "create-esengine-server" build
+          pnpm --filter "@esengine/node-editor" build
 
       - name: Create Release Pull Request or Publish
         id: changesets

--- a/packages/devtools/node-editor/package.json
+++ b/packages/devtools/node-editor/package.json
@@ -58,6 +58,5 @@
     "type": "git",
     "url": "https://github.com/esengine/esengine.git",
     "directory": "packages/devtools/node-editor"
-  },
-  "private": true
+  }
 }


### PR DESCRIPTION
## Summary
- 移除 package.json 中的 `private: true` | Remove `private: true` from package.json
- 在 CI 构建列表中添加 node-editor | Add node-editor to CI build list

## 原因 | Reason
changeset 发布失败是因为：
1. package.json 中有 `private: true` 阻止发布
2. CI workflow 没有包含 node-editor 的构建步骤

The changeset publish failed because:
1. `private: true` in package.json prevents publishing
2. CI workflow didn't include node-editor build step