### PR TITLE
fix(workspace): add devtools to root workspaces config

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "packages/network-ext/*",
     "packages/editor/*",
     "packages/editor/plugins/*",
+    "packages/devtools/*",
     "packages/rust/*",
     "packages/tools/*"
   ],


### PR DESCRIPTION
## Summary
在根目录 package.json 的 workspaces 字段中添加 `packages/devtools/*` | Add `packages/devtools/*` to root package.json workspaces field

## 原因 | Reason
Changesets 使用 package.json 的 workspaces 字段来确定 workspace 包列表，而不是 pnpm-workspace.yaml。
之前只更新了 pnpm-workspace.yaml，导致 changeset 找不到 @esengine/node-editor 包。

Changesets uses the workspaces field in package.json to determine workspace packages, not pnpm-workspace.yaml.
Previously only pnpm-workspace.yaml was updated, causing changeset to not find the @esengine/node-editor package.

## 验证 | Verification
修复后 `pnpm changeset status` 可以正确识别 @esengine/node-editor 包
After fix, `pnpm changeset status` correctly identifies @esengine/node-editor package