### PR TITLE
docs(blueprint): fix Cocos extension installation instructions

### DIFF
--- a/docs/src/content/docs/en/modules/blueprint/cocos-editor.md
+++ b/docs/src/content/docs/en/modules/blueprint/cocos-editor.md
@@ -7,36 +7,25 @@ This document explains how to install and use the blueprint visual scripting edi
 
 ## Installation
 
-### 1. Copy Extension to Project
+### 1. Download Extension
 
-Copy the `cocos-node-editor` extension to your Cocos Creator project's `extensions` directory:
+Download the `cocos-node-editor.zip` extension package from the release page.
 
-```
-your-project/
-├── assets/
-├── extensions/
-│   └── cocos-node-editor/    # Blueprint editor extension
-└── ...
-```
-
-### 2. Install Dependencies
-
-Install dependencies in the extension directory:
-
-```bash
-cd extensions/cocos-node-editor
-npm install
-```
-
-### 3. Enable Extension
+### 2. Import Extension
 
 1. Open Cocos Creator
 2. Go to **Extensions → Extension Manager**
-3. Find `cocos-node-editor` and enable it
+3. Click the **Import Extension** button
+4. Select the downloaded `cocos-node-editor.zip` file
+5. Enable the extension after importing
 
 ## Opening the Blueprint Editor
 
 Open the blueprint editor panel via menu **Panel → Node Editor**.
+
+### First Launch - Install Dependencies
+
+When opening the panel for the first time, the plugin will check if `@esengine/blueprint` is installed in your project. If not installed, it will display **"Missing required dependencies"** prompt. Click the **"Install Dependencies"** button to install automatically.
 
 ## Editor Interface
 

--- a/docs/src/content/docs/modules/blueprint/cocos-editor.md
+++ b/docs/src/content/docs/modules/blueprint/cocos-editor.md
@@ -7,36 +7,25 @@ description: "在 Cocos Creator 中使用蓝图可视化脚本系统"
 
 ## 安装扩展
 
-### 1. 复制扩展到项目
+### 1. 下载扩展
 
-将 `cocos-node-editor` 扩展复制到你的 Cocos Creator 项目的 `extensions` 目录：
+从发布页面下载 `cocos-node-editor.zip` 扩展包。
 
-```
-your-project/
-├── assets/
-├── extensions/
-│   └── cocos-node-editor/    # 蓝图编辑器扩展
-└── ...
-```
-
-### 2. 安装依赖
-
-在扩展目录中安装依赖：
-
-```bash
-cd extensions/cocos-node-editor
-npm install
-```
-
-### 3. 启用扩展
+### 2. 导入扩展
 
 1. 打开 Cocos Creator
 2. 进入 **扩展 → 扩展管理器**
-3. 找到 `cocos-node-editor` 并启用
+3. 点击 **导入扩展包** 按钮
+4. 选择下载的 `cocos-node-editor.zip` 文件
+5. 导入后启用扩展
 
 ## 打开蓝图编辑器
 
 通过菜单 **面板 → Node Editor** 打开蓝图编辑器面板。
+
+### 首次打开 - 安装依赖
+
+首次打开面板时，插件会检测项目中是否安装了 `@esengine/blueprint` 依赖包。如果未安装，会显示 **"缺少必要的依赖包"** 提示，点击 **"安装依赖"** 按钮即可自动安装。
 
 ## 编辑器界面
 


### PR DESCRIPTION
## Summary

Fix the Cocos Creator extension installation instructions to match the actual workflow.

## Changes

- Change from manual directory copy to zip import method
- Users import the `cocos-node-editor.zip` via Extension Manager
- Click **Install** button in Extension Manager after importing

## Before

The docs incorrectly instructed users to:
1. Manually copy extension folder to `extensions/` directory
2. Run `npm install` in terminal

## After

The docs now correctly describe:
1. Download `cocos-node-editor.zip`
2. Import via **Extensions → Extension Manager → Import Extension**
3. Click **Install** button in Extension Manager