### PR TITLE
fix(docs): 临时切换文档 URL 到 GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@
 </p>
 
 <p align="center">
-  <a href="https://esengine.cn/">Documentation</a> ·
-  <a href="https://esengine.cn/api/README">API Reference</a> ·
+  <a href="https://esengine.github.io/esengine/">Documentation</a> ·
+  <a href="https://esengine.github.io/esengine/api/README">API Reference</a> ·
   <a href="./examples/">Examples</a>
 </p>
 
@@ -283,7 +283,7 @@ pnpm test
 - [ECS Framework Guide](./packages/framework/core/README.md)
 - [Behavior Tree Guide](./packages/framework/behavior-tree/README.md)
 - [Editor Setup Guide](./packages/editor/editor-app/README.md) ([中文](./packages/editor/editor-app/README_CN.md))
-- [API Reference](https://esengine.cn/api/README)
+- [API Reference](https://esengine.github.io/esengine/api/README)
 
 ## Community
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -21,8 +21,8 @@
 </p>
 
 <p align="center">
-  <a href="https://esengine.cn/">文档</a> ·
-  <a href="https://esengine.cn/api/README">API 参考</a> ·
+  <a href="https://esengine.github.io/esengine/">文档</a> ·
+  <a href="https://esengine.github.io/esengine/api/README">API 参考</a> ·
   <a href="./examples/">示例</a>
 </p>
 
@@ -283,7 +283,7 @@ pnpm test
 - [ECS 框架指南](./packages/framework/core/README.md)
 - [行为树指南](./packages/framework/behavior-tree/README.md)
 - [编辑器启动指南](./packages/editor/editor-app/README_CN.md) ([English](./packages/editor/editor-app/README.md))
-- [API 参考](https://esengine.cn/api/README)
+- [API 参考](https://esengine.github.io/esengine/api/README)
 
 ## 社区
 

--- a/docs/public/CNAME
+++ b/docs/public/CNAME
@@ -1,1 +1,0 @@
-esengine.cn

--- a/docs/src/content/docs/en/modules/blueprint/editor-guide.md
+++ b/docs/src/content/docs/en/modules/blueprint/editor-guide.md
@@ -15,7 +15,7 @@ Download the latest version from GitHub Release (Free):
 
 **[Download Cocos Node Editor v1.2.0](https://github.com/esengine/esengine/releases/tag/cocos-node-editor-v1.2.0)**
 
-> QQ Group: **481923584** | Website: [esengine.cn](https://esengine.cn/)
+> QQ Group: **481923584** | Website: [esengine.cn](https://esengine.github.io/esengine/)
 
 ### Installation Steps
 

--- a/docs/src/content/docs/en/modules/blueprint/index.md
+++ b/docs/src/content/docs/en/modules/blueprint/index.md
@@ -11,7 +11,7 @@ Blueprint Editor Plugin for Cocos Creator (Free):
 
 **[Download Cocos Node Editor v1.2.0](https://github.com/esengine/esengine/releases/tag/cocos-node-editor-v1.2.0)**
 
-> QQ Group: **481923584** | Website: [esengine.cn](https://esengine.cn/)
+> QQ Group: **481923584** | Website: [esengine.cn](https://esengine.github.io/esengine/)
 
 For detailed usage instructions, see [Editor User Guide](./editor-guide).
 

--- a/docs/src/content/docs/modules/blueprint/editor-guide.md
+++ b/docs/src/content/docs/modules/blueprint/editor-guide.md
@@ -15,7 +15,7 @@ description: "Cocos Creator 蓝图可视化脚本编辑器完整使用教程"
 
 **[下载 Cocos Node Editor v1.2.0](https://github.com/esengine/esengine/releases/tag/cocos-node-editor-v1.2.0)**
 
-> 技术交流 QQ 群：**481923584** | 官网：[esengine.cn](https://esengine.cn/)
+> 技术交流 QQ 群：**481923584** | 官网：[esengine.cn](https://esengine.github.io/esengine/)
 
 ### 安装步骤
 

--- a/docs/src/content/docs/modules/blueprint/index.md
+++ b/docs/src/content/docs/modules/blueprint/index.md
@@ -11,7 +11,7 @@ Cocos Creator 蓝图编辑器插件（免费）：
 
 **[下载 Cocos Node Editor v1.2.0](https://github.com/esengine/esengine/releases/tag/cocos-node-editor-v1.2.0)**
 
-> 技术交流 QQ 群：**481923584** | 官网：[esengine.cn](https://esengine.cn/)
+> 技术交流 QQ 群：**481923584** | 官网：[esengine.cn](https://esengine.github.io/esengine/)
 
 详细使用教程请参考 [编辑器使用指南](./editor-guide)。
 

--- a/package.json
+++ b/package.json
@@ -76,7 +76,9 @@
     "build:wasm": "cd packages/rust/engine && wasm-pack build --dev --out-dir pkg",
     "build:wasm:release": "cd packages/rust/engine && wasm-pack build --release --out-dir pkg",
     "build:rapier2d": "node scripts/build-rapier2d.mjs",
-    "copy-modules": "node scripts/copy-engine-modules.mjs"
+    "copy-modules": "node scripts/copy-engine-modules.mjs",
+    "site:use-github": "node scripts/update-site-url.mjs",
+    "site:use-custom": "node scripts/update-site-url.mjs --to-alias"
   },
   "author": "yhh",
   "license": "MIT",

--- a/packages/editor/editor-app/README.md
+++ b/packages/editor/editor-app/README.md
@@ -124,7 +124,7 @@ The `pnpm build:rapier2d` script works directly on Windows. If you encounter iss
 
 ## Documentation
 
-- [ESEngine Documentation](https://esengine.cn/)
+- [ESEngine Documentation](https://esengine.github.io/esengine/)
 - [Tauri Documentation](https://tauri.app/)
 
 ## License

--- a/packages/editor/editor-app/README_CN.md
+++ b/packages/editor/editor-app/README_CN.md
@@ -124,7 +124,7 @@ rustup update
 
 ## 文档
 
-- [ESEngine 文档](https://esengine.cn/)
+- [ESEngine 文档](https://esengine.github.io/esengine/)
 - [Tauri 文档](https://tauri.app/)
 
 ## 许可证

--- a/packages/framework/core/README.md
+++ b/packages/framework/core/README.md
@@ -173,9 +173,9 @@ export class Main {
 
 ## Documentation
 
-- [API Reference](https://esengine.cn/api/README)
-- [Architecture Guide](https://esengine.cn/guide/)
-- [Full ESEngine Documentation](https://esengine.cn/)
+- [API Reference](https://esengine.github.io/esengine/api/README)
+- [Architecture Guide](https://esengine.github.io/esengine/guide/)
+- [Full ESEngine Documentation](https://esengine.github.io/esengine/)
 
 ## License
 

--- a/packages/framework/core/README_CN.md
+++ b/packages/framework/core/README_CN.md
@@ -173,9 +173,9 @@ export class Main {
 
 ## 文档
 
-- [API 参考](https://esengine.cn/api/README)
-- [架构指南](https://esengine.cn/guide/)
-- [完整 ESEngine 文档](https://esengine.cn/)
+- [API 参考](https://esengine.github.io/esengine/api/README)
+- [架构指南](https://esengine.github.io/esengine/guide/)
+- [完整 ESEngine 文档](https://esengine.github.io/esengine/)
 
 ## 许可证
 

--- a/scripts/update-site-url.mjs
+++ b/scripts/update-site-url.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+/**
+ * @zh 更新所有文档中的网站 URL
+ * @en Update website URL in all documentation files
+ *
+ * @zh 用法: node scripts/update-site-url.mjs [--to-alias]
+ * @en Usage: node scripts/update-site-url.mjs [--to-alias]
+ *
+ * @zh 默认使用 siteUrl，加 --to-alias 参数则使用 siteUrlAlias
+ * @en Uses siteUrl by default, use --to-alias flag to switch to siteUrlAlias
+ */
+
+import { readFileSync, writeFileSync, existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { glob } from 'glob';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const rootDir = join(__dirname, '..');
+
+// Load config
+const configPath = join(rootDir, 'site.config.json');
+if (!existsSync(configPath)) {
+    console.error('Error: site.config.json not found');
+    process.exit(1);
+}
+
+const config = JSON.parse(readFileSync(configPath, 'utf-8'));
+const useAlias = process.argv.includes('--to-alias');
+
+const fromUrl = useAlias ? config.siteUrl : config.siteUrlAlias;
+const toUrl = useAlias ? config.siteUrlAlias : config.siteUrl;
+
+console.log(`Updating URLs: ${fromUrl} -> ${toUrl}`);
+
+// Files to update
+const patterns = [
+    'README.md',
+    'README_CN.md',
+    'packages/**/README.md',
+    'packages/**/README_CN.md',
+    'docs/src/content/**/*.md',
+    'docs/public/CNAME',
+];
+
+// CNAME file handling
+const cnameFile = join(rootDir, 'docs/public/CNAME');
+if (useAlias) {
+    // Switching to custom domain - create CNAME
+    const domain = new URL(config.siteUrlAlias).hostname;
+    writeFileSync(cnameFile, domain + '\n');
+    console.log(`Created CNAME: ${domain}`);
+} else {
+    // Switching to GitHub Pages - remove CNAME
+    if (existsSync(cnameFile)) {
+        const { unlinkSync } = await import('fs');
+        unlinkSync(cnameFile);
+        console.log('Removed CNAME file');
+    }
+}
+
+// Update markdown files
+let updatedCount = 0;
+
+for (const pattern of patterns) {
+    if (pattern.includes('CNAME')) continue;
+
+    const files = await glob(pattern, {
+        cwd: rootDir,
+        absolute: true,
+        ignore: ['**/node_modules/**', '**/dist/**'],
+    });
+
+    for (const file of files) {
+        try {
+            const content = readFileSync(file, 'utf-8');
+            if (content.includes(fromUrl)) {
+                const newContent = content.replaceAll(fromUrl, toUrl);
+                writeFileSync(file, newContent);
+                console.log(`Updated: ${file.replace(rootDir, '')}`);
+                updatedCount++;
+            }
+        } catch (err) {
+            console.error(`Error processing ${file}: ${err.message}`);
+        }
+    }
+}
+
+console.log(`\nDone! Updated ${updatedCount} files.`);
+console.log(`Current site URL: ${toUrl}`);

--- a/site.config.json
+++ b/site.config.json
@@ -1,0 +1,5 @@
+{
+  "siteUrl": "https://esengine.github.io/esengine/",
+  "siteUrlAlias": "https://esengine.cn/",
+  "description": "网站 URL 配置。siteUrl 是当前使用的地址，siteUrlAlias 是备用地址（如备案后可切换回来）"
+}


### PR DESCRIPTION
## Summary

- esengine.cn 域名正在备案中无法访问，临时切换到 GitHub Pages 地址
- 将所有文档链接从 `esengine.cn` 替换为 `esengine.github.io/esengine`
- 删除 CNAME 文件以启用 GitHub Pages 默认域名
- 新增配置文件和脚本，方便日后切换

## 新增文件

- `site.config.json` - 网站 URL 配置
- `scripts/update-site-url.mjs` - URL 切换脚本

## 使用方法

备案完成后，运行以下命令即可切换回 esengine.cn：
```bash
pnpm site:use-custom
```

如需再次切换到 GitHub Pages：
```bash
pnpm site:use-github
```