### PR TITLE
fix(docs): add Astro site/base config for GitHub Pages

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -6,6 +6,8 @@ import tailwindcss from '@tailwindcss/vite';
 import rehypeRaw from 'rehype-raw';
 
 export default defineConfig({
+  site: 'https://esengine.github.io',
+  base: '/esengine',
   markdown: {
     rehypePlugins: [rehypeRaw],
   },

--- a/site.config.json
+++ b/site.config.json
@@ -1,5 +1,9 @@
 {
   "siteUrl": "https://esengine.github.io/esengine/",
   "siteUrlAlias": "https://esengine.cn/",
+  "astro": {
+    "github": { "site": "https://esengine.github.io", "base": "/esengine" },
+    "custom": { "site": "https://esengine.cn", "base": "" }
+  },
   "description": "网站 URL 配置。siteUrl 是当前使用的地址，siteUrlAlias 是备用地址（如备案后可切换回来）"
 }


### PR DESCRIPTION
## Summary

修复 GitHub Pages 上样式丢失的问题。

- 在 `astro.config.mjs` 中添加 `site` 和 `base` 配置
- 更新 `site.config.json` 添加 Astro 相关配置
- 更新切换脚本以同时处理 Astro 配置

## Problem

部署到 `https://esengine.github.io/esengine/` 时，CSS/JS 资源路径错误：
- 请求: `/xxx.css`
- 实际位置: `/esengine/xxx.css`

## Solution

```js
// docs/astro.config.mjs
export default defineConfig({
  site: 'https://esengine.github.io',
  base: '/esengine',
  // ...
});
```

合并后 GitHub Actions 重新构建即可修复样式问题。