### PR TITLE
fix(docs): use relative paths for internal links

### DIFF
--- a/docs/src/content/docs/en/guide/worker-system/index.md
+++ b/docs/src/content/docs/en/guide/worker-system/index.md
@@ -101,4 +101,4 @@ class PhysicsWorkerSystem extends WorkerEntitySystem<PhysicsData> {
 
 ## Live Demo
 
-[Worker System Demo](https://esengine.github.io/ecs-framework/demos/worker-system/)
+[Worker System Demo](https://esengine.github.io/esengine/demos/worker-system/)

--- a/docs/src/content/docs/en/index.mdx
+++ b/docs/src/content/docs/en/index.mdx
@@ -47,21 +47,21 @@ import { Card, CardGrid, LinkCard } from '@astrojs/starlight/components';
   <LinkCard
     title="5-Minute Start"
     description="From installation to creating your first ECS application, quickly understand core concepts."
-    href="/en/guide/getting-started/"
+    href="./guide/getting-started/"
   />
   <LinkCard
     title="Behavior Tree System"
     description="Built-in AI behavior tree system with visual editing and real-time debugging."
-    href="/en/modules/behavior-tree/"
+    href="./modules/behavior-tree/"
   />
   <LinkCard
     title="API Reference"
     description="Complete API documentation with detailed usage for every class and method."
-    href="/en/api/"
+    href="./api/"
   />
   <LinkCard
     title="Example Projects"
     description="View complete example projects and learn best practices."
-    href="/en/examples/"
+    href="./examples/"
   />
 </CardGrid>

--- a/docs/src/content/docs/examples/worker-system-demo.md
+++ b/docs/src/content/docs/examples/worker-system-demo.md
@@ -7,7 +7,7 @@ title: "Worker系统演示"
 ## 在线演示
 
 <div style="text-align: center; margin: 30px 0;">
-  <a href="/ecs-framework/demos/worker-system/index.html" target="_blank" style="display: inline-block; padding: 15px 30px; background: #4a9eff; color: white; text-decoration: none; border-radius: 8px; font-weight: bold; font-size: 16px; box-shadow: 0 4px 8px rgba(74, 158, 255, 0.3); transition: all 0.3s ease;">
+  <a href="/esengine/demos/worker-system/index.html" target="_blank" style="display: inline-block; padding: 15px 30px; background: #4a9eff; color: white; text-decoration: none; border-radius: 8px; font-weight: bold; font-size: 16px; box-shadow: 0 4px 8px rgba(74, 158, 255, 0.3); transition: all 0.3s ease;">
     🚀 打开Worker系统演示
   </a>
 </div>

--- a/docs/src/content/docs/guide/worker-system/index.md
+++ b/docs/src/content/docs/guide/worker-system/index.md
@@ -102,4 +102,4 @@ class PhysicsWorkerSystem extends WorkerEntitySystem<PhysicsData> {
 
 ## 在线演示
 
-[Worker 系统演示](https://esengine.github.io/ecs-framework/demos/worker-system/) - 多线程物理计算、实时性能对比
+[Worker 系统演示](https://esengine.github.io/esengine/demos/worker-system/) - 多线程物理计算、实时性能对比

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -47,21 +47,21 @@ import { Card, CardGrid, LinkCard } from '@astrojs/starlight/components';
   <LinkCard
     title="5 分钟上手"
     description="从安装到创建第一个 ECS 应用，快速了解核心概念。"
-    href="/guide/getting-started/"
+    href="./guide/getting-started/"
   />
   <LinkCard
     title="行为树系统"
     description="内置 AI 行为树系统，支持可视化编辑和实时调试。"
-    href="/modules/behavior-tree/"
+    href="./modules/behavior-tree/"
   />
   <LinkCard
     title="API 参考"
     description="完整的 API 文档，了解每个类和方法的详细用法。"
-    href="/api/"
+    href="./api/"
   />
   <LinkCard
     title="示例项目"
     description="查看完整的示例项目，学习最佳实践。"
-    href="/examples/"
+    href="./examples/"
   />
 </CardGrid>


### PR DESCRIPTION
## Summary

修复首页和文档中的内部链接，使用相对路径以适配 GitHub Pages 子路径部署。

## Changes

- 首页 LinkCard 链接改为相对路径 (`./guide/...`)
- Worker 演示链接路径从 `/ecs-framework/` 改为 `/esengine/`

## Files Changed

- `docs/src/content/docs/index.mdx`
- `docs/src/content/docs/en/index.mdx`
- `docs/src/content/docs/examples/worker-system-demo.md`
- `docs/src/content/docs/guide/worker-system/index.md`
- `docs/src/content/docs/en/guide/worker-system/index.md`