### PR TITLE
fix(docs): use relative path for hero action links

### DIFF
--- a/docs/src/content/docs/en/index.mdx
+++ b/docs/src/content/docs/en/index.mdx
@@ -8,7 +8,7 @@ hero:
     file: ../../../assets/logo.svg
   actions:
     - text: Quick Start
-      link: /en/guide/getting-started/
+      link: ./guide/getting-started/
       icon: right-arrow
       variant: primary
     - text: GitHub

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -8,7 +8,7 @@ hero:
     file: ../../assets/logo.svg
   actions:
     - text: 快速开始
-      link: /guide/getting-started/
+      link: ./guide/getting-started/
       icon: right-arrow
       variant: primary
     - text: GitHub


### PR DESCRIPTION
## Summary

修复首页 Hero 区域"快速开始"按钮的链接路径。

## Changes

- 中文首页: `link: /guide/getting-started/` → `link: ./guide/getting-started/`  
- 英文首页: `link: /en/guide/getting-started/` → `link: ./guide/getting-started/`

## Verification

已全面检查，所有内部链接均已使用相对路径：
- `link: /xxx` → 0 处
- `href="/xxx"` → 仅 `/esengine/demos/...` (已包含 base path)
- `](/xxx)` → 0 处