### PR TITLE
fix(math): 修复 npm 包发布配置

### DIFF
--- a/.changeset/fix-math-package-config.md
+++ b/.changeset/fix-math-package-config.md
@@ -1,0 +1,10 @@
+---
+"@esengine/ecs-framework-math": patch
+---
+
+fix(math): 修复 npm 包发布配置，入口从 bin 改为 dist
+
+- 修改 main/module/types 入口指向 dist 目录
+- 添加标准的 exports 字段配置
+- 移除 build-rollup.cjs 中生成 dist/package.json 的冗余逻辑
+- 与 @esengine/ecs-framework 包保持一致的发布配置

--- a/packages/framework/math/build-rollup.cjs
+++ b/packages/framework/math/build-rollup.cjs
@@ -14,11 +14,7 @@ async function main() {
 
         // 执行Rollup构建
         console.log('📦 执行 Rollup 构建...');
-        execSync('rollup -c rollup.config.cjs', { stdio: 'inherit' });
-
-        // 生成package.json
-        console.log('📋 生成 package.json...');
-        generatePackageJson();
+        execSync('npx rollup -c rollup.config.cjs', { stdio: 'inherit' });
 
         // 复制其他文件
         console.log('📁 复制必要文件...');
@@ -28,8 +24,6 @@ async function main() {
         showBuildResults();
 
         console.log('✅ 构建完成！');
-        console.log('\n🚀 发布命令:');
-        console.log('cd dist && npm publish');
 
     } catch (error) {
         console.error('❌ 构建失败:', error.message);
@@ -37,65 +31,9 @@ async function main() {
     }
 }
 
-function generatePackageJson() {
-    const sourcePackage = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
-    
-    const distPackage = {
-        name: sourcePackage.name,
-        version: sourcePackage.version,
-        description: sourcePackage.description,
-        main: 'index.cjs',
-        module: 'index.mjs',
-        unpkg: 'index.umd.js',
-        types: 'index.d.ts',
-        exports: {
-            '.': {
-                import: './index.mjs',
-                require: './index.cjs',
-                types: './index.d.ts'
-            }
-        },
-        files: [
-            'index.mjs',
-            'index.mjs.map',
-            'index.cjs',
-            'index.cjs.map',
-            'index.umd.js',
-            'index.umd.js.map',
-            'index.d.ts',
-            'README.md',
-            'LICENSE'
-        ],
-        keywords: [
-            'ecs',
-            'math',
-            '2d',
-            'vector',
-            'matrix',
-            'geometry',
-            'collision',
-            'game-engine',
-            'typescript',
-            'rollup'
-        ],
-        author: sourcePackage.author,
-        license: sourcePackage.license,
-        repository: sourcePackage.repository,
-        bugs: sourcePackage.bugs,
-        homepage: sourcePackage.homepage,
-        engines: {
-            node: '>=16.0.0'
-        },
-        sideEffects: false
-    };
-
-    fs.writeFileSync('./dist/package.json', JSON.stringify(distPackage, null, 2));
-}
-
 function copyFiles() {
     const filesToCopy = [
-        { src: './README.md', dest: './dist/README.md' },
-        { src: './LICENSE', dest: './dist/LICENSE' }
+        // 移除不存在的文件以避免警告
     ];
 
     filesToCopy.forEach(({ src, dest }) => {
@@ -106,12 +44,16 @@ function copyFiles() {
             console.log(`  ⚠️  文件不存在: ${src}`);
         }
     });
+
+    if (filesToCopy.length === 0) {
+        console.log('  ℹ️  没有需要复制的文件');
+    }
 }
 
 function showBuildResults() {
     const distDir = './dist';
     const files = ['index.mjs', 'index.cjs', 'index.umd.js', 'index.d.ts'];
-    
+
     console.log('\n📊 构建结果:');
     files.forEach(file => {
         const filePath = path.join(distDir, file);

--- a/packages/framework/math/package.json
+++ b/packages/framework/math/package.json
@@ -2,12 +2,22 @@
   "name": "@esengine/ecs-framework-math",
   "version": "2.10.1",
   "description": "ECS框架2D数学库 - 提供向量、矩阵、几何形状和碰撞检测功能",
-  "main": "bin/index.js",
-  "types": "bin/index.d.ts",
+  "type": "module",
+  "main": "dist/index.cjs",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "unpkg": "dist/index.umd.js",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs",
+      "source": "./src/index.ts"
+    }
+  },
   "files": [
-    "bin/**/*",
-    "README.md",
-    "LICENSE"
+    "dist/**/*"
   ],
   "keywords": [
     "ecs",
@@ -28,15 +38,14 @@
     "build:watch": "tsc --watch",
     "rebuild": "npm run clean && npm run build",
     "build:npm": "npm run build",
-    "publish:npm": "npm run build:npm && cd dist && npm publish",
     "test": "jest --config jest.config.cjs",
     "test:watch": "jest --watch --config jest.config.cjs",
     "test:coverage": "jest --coverage --config jest.config.cjs",
     "test:ci": "jest --ci --coverage --config jest.config.cjs",
     "test:clear": "jest --clearCache",
-    "publish:patch": "npm version patch && npm run build:npm && cd dist && npm publish",
-    "publish:minor": "npm version minor && npm run build:npm && cd dist && npm publish",
-    "publish:major": "npm version major && npm run build:npm && cd dist && npm publish"
+    "type-check": "npx tsc --noEmit",
+    "lint": "eslint \"src/**/*.{ts,tsx}\"",
+    "lint:fix": "eslint \"src/**/*.{ts,tsx}\" --fix"
   },
   "author": "yhh",
   "license": "MIT",
@@ -59,11 +68,12 @@
   },
   "publishConfig": {
     "access": "public",
-    "registry": "https://registry.npmjs.org/"
+    "registry": "https://registry.npmjs.org/",
+    "directory": "dist"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/esengine/esengine.git",
-    "directory": "packages/math"
+    "directory": "packages/framework/math"
   }
 }


### PR DESCRIPTION
## Summary
- 修复 `@esengine/ecs-framework-math` 包的 npm 发布配置
- 入口从错误的 `bin/` 目录改为正确的 `dist/` 目录
- 与 `@esengine/ecs-framework` 包保持一致的配置方式

## Changes
- `package.json`: main/module/types 指向 dist，添加标准 exports 配置
- `build-rollup.cjs`: 移除生成 dist/package.json 的冗余逻辑

## Test plan
- [x] 本地构建成功 (`pnpm run build`)
- [x] dist 目录输出正确的文件结构