### PR TITLE
feat(pathfinding): improve HPA* with lazy intra-edges and interactive demos

### DIFF
--- a/.changeset/hpa-pathfinder-improvements.md
+++ b/.changeset/hpa-pathfinder-improvements.md
@@ -1,0 +1,9 @@
+---
+"@esengine/pathfinding": minor
+---
+
+feat(pathfinding): improve HPA* algorithm with lazy intra-edges and better entrance node distribution
+
+- **Lazy Intra-Edges**: Delay intra-cluster path computation until first query, reducing preprocessing time from ~68s to ~52ms on large maps
+- **Entrance Node Distribution**: Fix path quality issue by distributing entrance nodes evenly across wide cluster boundaries instead of only placing at extremes
+- **Path Quality**: HPA* now produces near-optimal paths (ratio ~1.0 vs A*) on open maps, previously had significant detours

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -348,7 +348,18 @@ export default defineConfig({
           translations: { en: 'Examples' },
           items: [
             { label: '示例总览', slug: 'examples', translations: { en: 'Examples Overview' } },
-            { label: 'ORCA 局部避让', slug: 'examples/orca-avoidance-demo', translations: { en: 'ORCA Local Avoidance' } },
+            {
+              label: '寻路演示',
+              translations: { en: 'Pathfinding Demos' },
+              items: [
+                { label: 'A* 寻路', slug: 'examples/astar-pathfinding-demo', translations: { en: 'A* Pathfinding' } },
+                { label: '搜索可视化', slug: 'examples/search-visualization-demo', translations: { en: 'Search Visualization' } },
+                { label: '算法对比', slug: 'examples/algorithm-comparison-demo', translations: { en: 'Algorithm Comparison' } },
+                { label: 'HPA* 分层寻路', slug: 'examples/hpa-pathfinding-demo', translations: { en: 'HPA* Hierarchical' } },
+                { label: '多代理寻路', slug: 'examples/multi-agent-pathfinding-demo', translations: { en: 'Multi-Agent Pathfinding' } },
+                { label: 'ORCA 局部避让', slug: 'examples/orca-avoidance-demo', translations: { en: 'ORCA Local Avoidance' } },
+              ],
+            },
             { label: 'Worker 系统演示', slug: 'examples/worker-system-demo', translations: { en: 'Worker System Demo' } },
           ],
         },

--- a/docs/src/content/docs/en/examples/algorithm-comparison-demo.mdx
+++ b/docs/src/content/docs/en/examples/algorithm-comparison-demo.mdx
@@ -1,0 +1,405 @@
+---
+title: "Pathfinding Algorithm Comparison"
+description: "Compare A*, Bidirectional A*, and JPS algorithm performance and search process"
+---
+
+import DemoPlayground from '../../../../components/DemoPlayground.vue';
+
+export const algoScenes = [
+    { id: 'open', label: '○', name: 'Open Terrain' },
+    { id: 'maze', label: '⬛', name: 'Maze' },
+    { id: 'rooms', label: '⬜', name: 'Rooms' },
+    { id: 'dense', label: '▓', name: 'Dense Obstacles' }
+];
+
+export const algoParams = [
+    { id: 'gridSize', label: 'Grid', desc: 'Grid size', value: 60, min: 30, max: 100, step: 10 },
+    { id: 'obstacleRate', label: 'Obstacles', desc: 'Obstacle density (%)', value: 30, min: 10, max: 50, step: 5 }
+];
+
+export const algoDemoCode = `// Pathfinding Algorithm Comparison - A* vs Bidirectional A* vs JPS
+// ============================================
+// Compare search efficiency and path quality of different algorithms
+
+const {
+    Core, Scene, Component, EntitySystem, Matcher, Time,
+    ECSComponent, ECSSystem,
+    GridMap, createGridMap,
+    AStarPathfinder, GridPathfinder, JPSPathfinder,
+    octileDistance
+} = ESEngine;
+
+const WIDTH = 580, HEIGHT = 380;
+
+const params = window.__demoParams || {
+    gridSize: 60, obstacleRate: 30
+};
+
+// Algorithm results storage
+let results = {
+    astar: { time: 0, nodes: 0, pathLen: 0, path: [] },
+    bidir: { time: 0, nodes: 0, pathLen: 0, path: [] },
+    jps: { time: 0, nodes: 0, pathLen: 0, path: [] }
+};
+
+let gridMap = null;
+let startPos = { x: 2, y: 2 };
+let endPos = { x: 0, y: 0 };
+let selectedAlgo = 'all'; // 'all', 'astar', 'bidir', 'jps'
+
+// ============================================
+// Rendering
+// ============================================
+
+function render(ctx) {
+    if (!gridMap) return;
+
+    const cellW = WIDTH / gridMap.width;
+    const cellH = HEIGHT / gridMap.height;
+
+    // Clear screen
+    ctx.fillStyle = '#16213e';
+    ctx.fillRect(0, 0, WIDTH, HEIGHT);
+
+    // Draw obstacles
+    ctx.fillStyle = '#2d4263';
+    for (let y = 0; y < gridMap.height; y++) {
+        for (let x = 0; x < gridMap.width; x++) {
+            if (!gridMap.isWalkable(x, y)) {
+                ctx.fillRect(x * cellW, y * cellH, cellW - 1, cellH - 1);
+            }
+        }
+    }
+
+    // Draw grid lines
+    ctx.strokeStyle = 'rgba(255,255,255,0.03)';
+    ctx.lineWidth = 1;
+    for (let x = 0; x <= gridMap.width; x++) {
+        ctx.beginPath();
+        ctx.moveTo(x * cellW, 0);
+        ctx.lineTo(x * cellW, HEIGHT);
+        ctx.stroke();
+    }
+    for (let y = 0; y <= gridMap.height; y++) {
+        ctx.beginPath();
+        ctx.moveTo(0, y * cellH);
+        ctx.lineTo(WIDTH, y * cellH);
+        ctx.stroke();
+    }
+
+    // Draw paths
+    const colors = {
+        astar: { stroke: '#ff6b6b', fill: 'rgba(255,107,107,0.3)', name: 'A*' },
+        bidir: { stroke: '#4ecdc4', fill: 'rgba(78,205,196,0.3)', name: 'Bidirectional' },
+        jps: { stroke: '#ffe66d', fill: 'rgba(255,230,109,0.3)', name: 'JPS' }
+    };
+
+    const drawPath = (path, color, offset) => {
+        if (path.length < 2) return;
+        ctx.strokeStyle = color.stroke;
+        ctx.lineWidth = 2;
+        ctx.beginPath();
+        ctx.moveTo(path[0].x * cellW + cellW/2 + offset, path[0].y * cellH + cellH/2);
+        for (let i = 1; i < path.length; i++) {
+            ctx.lineTo(path[i].x * cellW + cellW/2 + offset, path[i].y * cellH + cellH/2);
+        }
+        ctx.stroke();
+    };
+
+    // Show paths based on selection
+    if (selectedAlgo === 'all' || selectedAlgo === 'astar') {
+        drawPath(results.astar.path, colors.astar, -2);
+    }
+    if (selectedAlgo === 'all' || selectedAlgo === 'bidir') {
+        drawPath(results.bidir.path, colors.bidir, 0);
+    }
+    if (selectedAlgo === 'all' || selectedAlgo === 'jps') {
+        drawPath(results.jps.path, colors.jps, 2);
+    }
+
+    // Draw start and end points
+    ctx.fillStyle = '#00d4ff';
+    ctx.beginPath();
+    ctx.arc(startPos.x * cellW + cellW/2, startPos.y * cellH + cellH/2, 6, 0, Math.PI * 2);
+    ctx.fill();
+
+    ctx.fillStyle = '#ff6b6b';
+    ctx.beginPath();
+    ctx.arc(endPos.x * cellW + cellW/2, endPos.y * cellH + cellH/2, 6, 0, Math.PI * 2);
+    ctx.fill();
+
+    // HUD - Algorithm comparison panel
+    const panelX = 5, panelY = 5;
+    const panelW = 200, panelH = 95;
+    ctx.fillStyle = 'rgba(0,0,0,0.75)';
+    ctx.fillRect(panelX, panelY, panelW, panelH);
+
+    ctx.font = 'bold 11px monospace';
+    ctx.fillStyle = '#fff';
+    ctx.fillText('Algorithm Comparison', panelX + 5, panelY + 15);
+
+    ctx.font = '10px monospace';
+    const algos = ['astar', 'bidir', 'jps'];
+    const labels = ['A*', 'Bi-A*', 'JPS'];
+
+    // Header
+    ctx.fillStyle = '#888';
+    ctx.fillText('Algo    Time    Nodes   Path', panelX + 5, panelY + 30);
+
+    algos.forEach((algo, i) => {
+        const r = results[algo];
+        const y = panelY + 45 + i * 15;
+        ctx.fillStyle = colors[algo].stroke;
+        ctx.fillText(
+            \`\${labels[i].padEnd(6)} \${r.time.toFixed(2).padStart(6)}ms \${String(r.nodes).padStart(5)} \${String(r.pathLen).padStart(5)}\`,
+            panelX + 5, y
+        );
+    });
+
+    // Hint
+    ctx.fillStyle = '#666';
+    ctx.font = '9px monospace';
+    ctx.fillText('Click: set start/end', panelX + 5, panelY + 90);
+
+    // Legend
+    const legendX = WIDTH - 95, legendY = 5;
+    ctx.fillStyle = 'rgba(0,0,0,0.75)';
+    ctx.fillRect(legendX, legendY, 90, 55);
+    ctx.font = '10px monospace';
+    algos.forEach((algo, i) => {
+        ctx.fillStyle = colors[algo].stroke;
+        ctx.fillRect(legendX + 5, legendY + 8 + i * 15, 10, 10);
+        ctx.fillText(labels[i], legendX + 20, legendY + 17 + i * 15);
+    });
+}
+
+// ============================================
+// Pathfinding Execution
+// ============================================
+
+function runPathfinding() {
+    if (!gridMap) return;
+
+    const options = {
+        allowDiagonal: true,
+        heuristic: octileDistance
+    };
+
+    // Standard A*
+    const astar = new AStarPathfinder(gridMap);
+    let t0 = performance.now();
+    let result = astar.findPath(startPos.x, startPos.y, endPos.x, endPos.y, options);
+    results.astar = {
+        time: performance.now() - t0,
+        nodes: result.nodesSearched,
+        pathLen: result.path.length,
+        path: result.path
+    };
+
+    // Bidirectional A*
+    const bidir = new GridPathfinder(gridMap, { mode: 'bidirectional' });
+    t0 = performance.now();
+    result = bidir.findPath(startPos.x, startPos.y, endPos.x, endPos.y, options);
+    results.bidir = {
+        time: performance.now() - t0,
+        nodes: result.nodesSearched,
+        pathLen: result.path.length,
+        path: result.path
+    };
+
+    // JPS
+    const jps = new JPSPathfinder(gridMap);
+    t0 = performance.now();
+    result = jps.findPath(startPos.x, startPos.y, endPos.x, endPos.y, { allowDiagonal: true });
+    results.jps = {
+        time: performance.now() - t0,
+        nodes: result.nodesSearched,
+        pathLen: result.path.length,
+        path: result.path
+    };
+}
+
+// ============================================
+// Map Generation
+// ============================================
+
+function generateMap(type) {
+    const w = params.gridSize;
+    const h = Math.floor(w * HEIGHT / WIDTH);
+
+    gridMap = createGridMap(w, h);
+
+    const generators = {
+        open: () => {
+            // Few random obstacles
+            const rate = 0.1;
+            for (let y = 0; y < h; y++) {
+                for (let x = 0; x < w; x++) {
+                    if (Math.random() < rate) gridMap.setWalkable(x, y, false);
+                }
+            }
+        },
+        maze: () => {
+            // Maze
+            for (let y = 0; y < h; y++) {
+                for (let x = 0; x < w; x++) {
+                    gridMap.setWalkable(x, y, false);
+                }
+            }
+            const carve = (x, y) => {
+                gridMap.setWalkable(x, y, true);
+                const dirs = [[0,-2],[0,2],[-2,0],[2,0]].sort(() => Math.random() - 0.5);
+                for (const [dx, dy] of dirs) {
+                    const nx = x + dx, ny = y + dy;
+                    if (nx > 0 && nx < w-1 && ny > 0 && ny < h-1 && !gridMap.isWalkable(nx, ny)) {
+                        gridMap.setWalkable(x + dx/2, y + dy/2, true);
+                        carve(nx, ny);
+                    }
+                }
+            };
+            carve(1, 1);
+        },
+        rooms: () => {
+            // Room layout
+            const roomW = Math.floor(w / 4);
+            const roomH = Math.floor(h / 3);
+            for (let ry = 0; ry < 3; ry++) {
+                for (let rx = 0; rx < 4; rx++) {
+                    const bx = rx * roomW, by = ry * roomH;
+                    for (let x = bx; x < bx + roomW && x < w; x++) {
+                        if (by < h) gridMap.setWalkable(x, by, false);
+                        if (by + roomH - 1 < h) gridMap.setWalkable(x, by + roomH - 1, false);
+                    }
+                    for (let y = by; y < by + roomH && y < h; y++) {
+                        if (bx < w) gridMap.setWalkable(bx, y, false);
+                        if (bx + roomW - 1 < w) gridMap.setWalkable(bx + roomW - 1, y, false);
+                    }
+                    // Doors
+                    const doorX = bx + Math.floor(roomW / 2);
+                    const doorY = by + Math.floor(roomH / 2);
+                    if (doorX < w && by < h) gridMap.setWalkable(doorX, by, true);
+                    if (doorX < w && by + roomH - 1 < h) gridMap.setWalkable(doorX, by + roomH - 1, true);
+                    if (bx < w && doorY < h) gridMap.setWalkable(bx, doorY, true);
+                    if (bx + roomW - 1 < w && doorY < h) gridMap.setWalkable(bx + roomW - 1, doorY, true);
+                }
+            }
+        },
+        dense: () => {
+            // Dense random obstacles
+            const rate = params.obstacleRate / 100;
+            for (let y = 0; y < h; y++) {
+                for (let x = 0; x < w; x++) {
+                    if (Math.random() < rate) gridMap.setWalkable(x, y, false);
+                }
+            }
+        }
+    };
+
+    generators[type]?.();
+
+    // Set start and end
+    startPos = findWalkable(2, 2);
+    endPos = findWalkable(w - 3, h - 3);
+
+    runPathfinding();
+}
+
+function findWalkable(px, py) {
+    if (gridMap.isWalkable(px, py)) return { x: px, y: py };
+    for (let r = 1; r < 20; r++) {
+        for (let dx = -r; dx <= r; dx++) {
+            for (let dy = -r; dy <= r; dy++) {
+                const x = px + dx, y = py + dy;
+                if (x >= 0 && x < gridMap.width && y >= 0 && y < gridMap.height) {
+                    if (gridMap.isWalkable(x, y)) return { x, y };
+                }
+            }
+        }
+    }
+    return { x: 1, y: 1 };
+}
+
+// ============================================
+// Initialize
+// ============================================
+
+generateMap('open');
+
+// Mouse interaction
+let clickMode = 'start'; // 'start' or 'end'
+canvas.addEventListener('click', (e) => {
+    const rect = canvas.getBoundingClientRect();
+    const mx = (e.clientX - rect.left) * (canvas.width / rect.width);
+    const my = (e.clientY - rect.top) * (canvas.height / rect.height);
+    const cellW = WIDTH / gridMap.width;
+    const cellH = HEIGHT / gridMap.height;
+    const gx = Math.floor(mx / cellW);
+    const gy = Math.floor(my / cellH);
+
+    if (gridMap.isWalkable(gx, gy)) {
+        if (clickMode === 'start') {
+            startPos = { x: gx, y: gy };
+            clickMode = 'end';
+        } else {
+            endPos = { x: gx, y: gy };
+            clickMode = 'start';
+        }
+        runPathfinding();
+    }
+});
+
+// Scene switching support
+window.__demoScene = {
+    loadScenario: (type) => {
+        generateMap(type);
+    }
+};
+
+// Game loop
+function gameLoop() {
+    render(ctx);
+    requestAnimationFrame(gameLoop);
+}
+
+gameLoop();`;
+
+This is a **pathfinding algorithm comparison demo** showing performance differences between A*, Bidirectional A*, and JPS algorithms.
+
+Click **Run** to start. Click on the map to set start/end points and observe the search efficiency of different algorithms.
+
+**Algorithm Characteristics:**
+- **A*** - Classic heuristic search, suitable for small to medium maps
+- **Bidirectional A*** - Searches from both start and end simultaneously, more efficient for large maps
+- **JPS (Jump Point Search)** - Significant advantage on open terrain, can skip many nodes
+
+<DemoPlayground
+    client:load
+    title="Algorithm Comparison - A* vs Bidirectional A* vs JPS"
+    code={algoDemoCode}
+    canvasWidth={580}
+    canvasHeight={380}
+    scenes={algoScenes}
+    params={algoParams}
+/>
+
+<script is:inline src="/esengine/js/esengine.iife.js"></script>
+
+## Performance Metrics
+
+| Metric | Description |
+|--------|-------------|
+| **Time** | Pathfinding time (milliseconds) |
+| **Nodes** | Number of nodes searched (fewer = more efficient) |
+| **Path** | Final path length (node count) |
+
+## Scene Descriptions
+
+- **Open Terrain** - JPS shows significant advantage, can skip large empty areas
+- **Maze** - Narrow corridors, smaller difference between algorithms
+- **Rooms** - Simulates indoor environment, requires passing through doorways
+- **Dense Obstacles** - Random distribution, tests general cases
+
+## Related Documentation
+
+- [A* Pathfinding Demo](/esengine/en/examples/astar-pathfinding-demo) - Basic A* demo
+- [Pathfinding System API](/esengine/en/modules/pathfinding) - Complete API documentation

--- a/docs/src/content/docs/en/examples/astar-pathfinding-demo.mdx
+++ b/docs/src/content/docs/en/examples/astar-pathfinding-demo.mdx
@@ -1,0 +1,489 @@
+---
+title: "A* Pathfinding Demo"
+description: "Interactive A* grid pathfinding demo using ECS architecture"
+---
+
+import DemoPlayground from '../../../../components/DemoPlayground.vue';
+
+export const astarScenes = [
+    { id: 'maze', label: '⬛', name: 'Maze' },
+    { id: 'random', label: '✦', name: 'Random Obstacles' },
+    { id: 'rooms', label: '⬜', name: 'Rooms' },
+    { id: 'spiral', label: '◎', name: 'Spiral' }
+];
+
+export const astarParams = [
+    { id: 'gridSize', label: 'Grid', desc: 'Grid size (higher = finer)', value: 40, min: 20, max: 80, step: 10 },
+    { id: 'obstacleRate', label: 'Obstacles', desc: 'Obstacle density (%)', value: 25, min: 10, max: 50, step: 5 },
+    { id: 'diagonal', label: 'Diagonal', desc: 'Allow diagonal movement (0=no, 1=yes)', value: 1, min: 0, max: 1, step: 1 },
+    { id: 'speed', label: 'Speed', desc: 'Movement speed (grids/sec)', value: 5, min: 1, max: 15, step: 1 }
+];
+
+export const astarDemoCode = `// A* Pathfinding - ECS Architecture Demo
+// ============================================
+// Click the map to set start and end points, observe A* pathfinding process
+
+const {
+    Core, Scene, Component, EntitySystem, Matcher, Time,
+    ECSComponent, ECSSystem,
+    PathfindingAgentComponent, PathfindingMapComponent, PathfindingSystem
+} = ESEngine;
+
+const WIDTH = 580, HEIGHT = 380;
+
+const params = window.__demoParams || {
+    gridSize: 40, obstacleRate: 25, diagonal: 1, speed: 5
+};
+
+// ============================================
+// Component Definitions
+// ============================================
+
+@ECSComponent('Visual')
+class VisualComponent extends Component {
+    color = '#00d4ff';
+    showPath = true;
+}
+
+// ============================================
+// Render System
+// ============================================
+
+@ECSSystem('Render', { updateOrder: 100 })
+class RenderSystem extends EntitySystem {
+    ctx: CanvasRenderingContext2D;
+    mapComp: PathfindingMapComponent | null = null;
+    fps = 0; frameCount = 0; lastFpsTime = 0;
+
+    constructor(context: CanvasRenderingContext2D) {
+        super(Matcher.all(PathfindingAgentComponent, VisualComponent));
+        this.ctx = context;
+    }
+
+    process(entities) {
+        const ctx = this.ctx;
+
+        // Clear screen
+        ctx.fillStyle = '#16213e';
+        ctx.fillRect(0, 0, WIDTH, HEIGHT);
+
+        // Find map component
+        if (!this.mapComp) {
+            const mapEntities = this.scene.entities.findEntitiesWithComponent(PathfindingMapComponent);
+            if (mapEntities.length > 0) {
+                this.mapComp = mapEntities[0].getComponent(PathfindingMapComponent);
+            }
+        }
+
+        // Draw grid
+        if (this.mapComp?.map) {
+            const map = this.mapComp.map;
+            const cellW = WIDTH / map.width;
+            const cellH = HEIGHT / map.height;
+
+            // Draw obstacles
+            ctx.fillStyle = '#2d4263';
+            for (let y = 0; y < map.height; y++) {
+                for (let x = 0; x < map.width; x++) {
+                    if (!map.isWalkable(x, y)) {
+                        ctx.fillRect(x * cellW, y * cellH, cellW - 1, cellH - 1);
+                    }
+                }
+            }
+
+            // Draw grid lines
+            ctx.strokeStyle = 'rgba(255,255,255,0.05)';
+            ctx.lineWidth = 1;
+            for (let x = 0; x <= map.width; x++) {
+                ctx.beginPath();
+                ctx.moveTo(x * cellW, 0);
+                ctx.lineTo(x * cellW, HEIGHT);
+                ctx.stroke();
+            }
+            for (let y = 0; y <= map.height; y++) {
+                ctx.beginPath();
+                ctx.moveTo(0, y * cellH);
+                ctx.lineTo(WIDTH, y * cellH);
+                ctx.stroke();
+            }
+        }
+
+        // FPS calculation
+        this.frameCount++;
+        const now = performance.now();
+        if (now - this.lastFpsTime >= 1000) {
+            this.fps = this.frameCount;
+            this.frameCount = 0;
+            this.lastFpsTime = now;
+        }
+
+        // Draw agents and paths
+        for (const entity of entities) {
+            const agent = entity.getComponent(PathfindingAgentComponent);
+            const visual = entity.getComponent(VisualComponent);
+
+            if (!this.mapComp?.map) continue;
+            const cellW = WIDTH / this.mapComp.map.width;
+            const cellH = HEIGHT / this.mapComp.map.height;
+
+            // Draw path
+            if (visual.showPath && agent.path.length > 0) {
+                ctx.strokeStyle = 'rgba(0, 212, 255, 0.4)';
+                ctx.lineWidth = 3;
+                ctx.beginPath();
+                ctx.moveTo(agent.x * cellW + cellW/2, agent.y * cellH + cellH/2);
+                for (const p of agent.path) {
+                    ctx.lineTo(p.x * cellW + cellW/2, p.y * cellH + cellH/2);
+                }
+                ctx.stroke();
+
+                // Draw path points
+                ctx.fillStyle = 'rgba(0, 212, 255, 0.6)';
+                for (let i = agent.pathIndex; i < agent.path.length; i++) {
+                    const p = agent.path[i];
+                    ctx.beginPath();
+                    ctx.arc(p.x * cellW + cellW/2, p.y * cellH + cellH/2, 3, 0, Math.PI * 2);
+                    ctx.fill();
+                }
+            }
+
+            // Draw target point
+            ctx.fillStyle = '#ff6b6b';
+            ctx.beginPath();
+            ctx.arc(agent.targetX * cellW + cellW/2, agent.targetY * cellH + cellH/2, 6, 0, Math.PI * 2);
+            ctx.fill();
+
+            // Draw agent
+            const x = agent.x * cellW + cellW/2;
+            const y = agent.y * cellH + cellH/2;
+
+            // Glow
+            const gradient = ctx.createRadialGradient(x, y, 0, x, y, 12);
+            gradient.addColorStop(0, visual.color);
+            gradient.addColorStop(1, 'transparent');
+            ctx.beginPath();
+            ctx.arc(x, y, 12, 0, Math.PI * 2);
+            ctx.fillStyle = gradient;
+            ctx.fill();
+
+            // Agent circle
+            ctx.beginPath();
+            ctx.arc(x, y, 6, 0, Math.PI * 2);
+            ctx.fillStyle = visual.color;
+            ctx.fill();
+        }
+
+        // HUD
+        ctx.fillStyle = 'rgba(0,0,0,0.6)';
+        ctx.fillRect(5, 5, 140, 50);
+        ctx.fillStyle = '#00d4ff';
+        ctx.font = '11px monospace';
+        ctx.fillText(\`Grid: \${this.mapComp?.width || 0}x\${this.mapComp?.height || 0}\`, 10, 20);
+        ctx.fillText(\`FPS: \${this.fps}\`, 10, 32);
+        const agent = entities[0]?.getComponent(PathfindingAgentComponent);
+        ctx.fillText(\`Path: \${agent?.path.length || 0} nodes\`, 10, 44);
+    }
+}
+
+// ============================================
+// Movement System
+// ============================================
+
+@ECSSystem('Movement', { updateOrder: 50 })
+class MovementSystem extends EntitySystem {
+    mapComp: PathfindingMapComponent | null = null;
+
+    constructor() {
+        super(Matcher.all(PathfindingAgentComponent));
+    }
+
+    process(entities) {
+        if (!this.mapComp) {
+            const mapEntities = this.scene.entities.findEntitiesWithComponent(PathfindingMapComponent);
+            if (mapEntities.length > 0) {
+                this.mapComp = mapEntities[0].getComponent(PathfindingMapComponent);
+            }
+        }
+        if (!this.mapComp?.map) return;
+
+        const cellW = WIDTH / this.mapComp.map.width;
+        const cellH = HEIGHT / this.mapComp.map.height;
+        const dt = Time.deltaTime;
+        const moveSpeed = params.speed * dt;
+
+        for (const entity of entities) {
+            const agent = entity.getComponent(PathfindingAgentComponent);
+
+            if (!agent.hasValidPath() || agent.isPathComplete()) continue;
+
+            const waypoint = agent.getNextWaypoint();
+            if (!waypoint) continue;
+
+            const dx = waypoint.x - agent.x;
+            const dy = waypoint.y - agent.y;
+            const dist = Math.sqrt(dx * dx + dy * dy);
+
+            if (dist < 0.1) {
+                agent.x = waypoint.x;
+                agent.y = waypoint.y;
+                agent.advanceWaypoint();
+            } else {
+                const moveRatio = Math.min(moveSpeed / dist, 1);
+                agent.x += dx * moveRatio;
+                agent.y += dy * moveRatio;
+            }
+        }
+    }
+}
+
+// ============================================
+// Scene
+// ============================================
+
+class AStarDemoScene extends Scene {
+    mapEntity: any;
+    agentEntity: any;
+
+    initialize() {
+        this.name = 'AStarDemo';
+        this.addSystem(new PathfindingSystem());
+        this.addSystem(new MovementSystem());
+        this.addSystem(new RenderSystem(ctx));
+    }
+
+    onStart() {
+        this.loadScenario('maze');
+    }
+
+    loadScenario(type: string) {
+        console.log('loadScenario called:', type);
+
+        // Clear existing entities (use correct API)
+        if (this.mapEntity) {
+            this.mapEntity.destroy();
+            this.mapEntity = null;
+        }
+        if (this.agentEntity) {
+            this.agentEntity.destroy();
+            this.agentEntity = null;
+        }
+
+        // Reset render system's map reference
+        for (const system of this.systems) {
+            if (system.mapComp) system.mapComp = null;
+        }
+
+        const gridSize = params.gridSize;
+
+        // Create map entity
+        this.mapEntity = this.createEntity('Map');
+        const mapComp = this.mapEntity.addComponent(new PathfindingMapComponent());
+        mapComp.width = gridSize;
+        mapComp.height = Math.floor(gridSize * HEIGHT / WIDTH);
+        mapComp.allowDiagonal = params.diagonal === 1;
+        mapComp.avoidCorners = true;
+        mapComp.enableSmoothing = false;
+
+        // Create agent
+        this.agentEntity = this.createEntity('Agent');
+        const agent = this.agentEntity.addComponent(new PathfindingAgentComponent());
+        const visual = this.agentEntity.addComponent(new VisualComponent());
+        visual.color = '#00d4ff';
+
+        // Wait for map initialization then generate obstacles
+        setTimeout(() => {
+            if (!mapComp.map) return;
+
+            const generators = {
+                maze: () => this.generateMaze(mapComp),
+                random: () => this.generateRandom(mapComp),
+                rooms: () => this.generateRooms(mapComp),
+                spiral: () => this.generateSpiral(mapComp)
+            };
+            generators[type]?.();
+
+            // Find start and end points (spiral: center to edge)
+            let start, end;
+            if (type === 'spiral') {
+                const cx = Math.floor(mapComp.width / 2);
+                const cy = Math.floor(mapComp.height / 2);
+                start = { x: cx, y: cy };  // center
+                end = this.findWalkable(mapComp, 1, 1);  // edge
+            } else {
+                start = this.findWalkable(mapComp, 1, 1);
+                end = this.findWalkable(mapComp, mapComp.width - 2, mapComp.height - 2);
+            }
+
+            agent.x = start.x;
+            agent.y = start.y;
+            agent.requestPathTo(end.x, end.y);
+        }, 100);
+    }
+
+    findWalkable(mapComp, preferX, preferY) {
+        if (mapComp.isWalkable(preferX, preferY)) return { x: preferX, y: preferY };
+        for (let r = 1; r < 10; r++) {
+            for (let dx = -r; dx <= r; dx++) {
+                for (let dy = -r; dy <= r; dy++) {
+                    const x = preferX + dx, y = preferY + dy;
+                    if (x >= 0 && x < mapComp.width && y >= 0 && y < mapComp.height) {
+                        if (mapComp.isWalkable(x, y)) return { x, y };
+                    }
+                }
+            }
+        }
+        return { x: 1, y: 1 };
+    }
+
+    generateMaze(mapComp) {
+        const w = mapComp.width, h = mapComp.height;
+        // Fill all as walls
+        for (let y = 0; y < h; y++) {
+            for (let x = 0; x < w; x++) {
+                mapComp.setWalkable(x, y, false);
+            }
+        }
+        // Recursive division maze generation
+        const carve = (x, y) => {
+            mapComp.setWalkable(x, y, true);
+            const dirs = [[0,-2],[0,2],[-2,0],[2,0]].sort(() => Math.random() - 0.5);
+            for (const [dx, dy] of dirs) {
+                const nx = x + dx, ny = y + dy;
+                if (nx > 0 && nx < w-1 && ny > 0 && ny < h-1 && !mapComp.isWalkable(nx, ny)) {
+                    mapComp.setWalkable(x + dx/2, y + dy/2, true);
+                    carve(nx, ny);
+                }
+            }
+        };
+        carve(1, 1);
+    }
+
+    generateRandom(mapComp) {
+        const w = mapComp.width, h = mapComp.height;
+        const rate = params.obstacleRate / 100;
+        for (let y = 0; y < h; y++) {
+            for (let x = 0; x < w; x++) {
+                if (x === 1 && y === 1) continue;
+                if (x === w-2 && y === h-2) continue;
+                mapComp.setWalkable(x, y, Math.random() > rate);
+            }
+        }
+    }
+
+    generateRooms(mapComp) {
+        const w = mapComp.width, h = mapComp.height;
+        // All walkable
+        for (let y = 0; y < h; y++) {
+            for (let x = 0; x < w; x++) {
+                mapComp.setWalkable(x, y, true);
+            }
+        }
+        // Generate room walls
+        const roomW = Math.floor(w / 4);
+        const roomH = Math.floor(h / 3);
+        for (let ry = 0; ry < 3; ry++) {
+            for (let rx = 0; rx < 4; rx++) {
+                const bx = rx * roomW, by = ry * roomH;
+                // Draw walls
+                for (let x = bx; x < bx + roomW && x < w; x++) {
+                    if (by < h) mapComp.setWalkable(x, by, false);
+                    if (by + roomH - 1 < h) mapComp.setWalkable(x, by + roomH - 1, false);
+                }
+                for (let y = by; y < by + roomH && y < h; y++) {
+                    if (bx < w) mapComp.setWalkable(bx, y, false);
+                    if (bx + roomW - 1 < w) mapComp.setWalkable(bx + roomW - 1, y, false);
+                }
+                // Open doors
+                const doorX = bx + Math.floor(roomW / 2);
+                const doorY = by + Math.floor(roomH / 2);
+                if (doorX < w && by < h) mapComp.setWalkable(doorX, by, true);
+                if (doorX < w && by + roomH - 1 < h) mapComp.setWalkable(doorX, by + roomH - 1, true);
+                if (bx < w && doorY < h) mapComp.setWalkable(bx, doorY, true);
+                if (bx + roomW - 1 < w && doorY < h) mapComp.setWalkable(bx + roomW - 1, doorY, true);
+            }
+        }
+    }
+
+    generateSpiral(mapComp) {
+        const w = mapComp.width, h = mapComp.height;
+        const cx = Math.floor(w / 2), cy = Math.floor(h / 2);
+        const maxDist = Math.min(cx, cy) - 1;
+
+        // Start with all walkable
+        for (let y = 0; y < h; y++) {
+            for (let x = 0; x < w; x++) {
+                mapComp.setWalkable(x, y, true);
+            }
+        }
+
+        // Create concentric ring walls with openings
+        for (let ring = 3; ring < maxDist; ring += 3) {
+            // Each ring has an opening at different angle
+            const openingAngle = (ring * 0.5) % (Math.PI * 2);
+
+            for (let angle = 0; angle < Math.PI * 2; angle += 0.1) {
+                // Skip opening area
+                const angleDiff = Math.abs(((angle - openingAngle + Math.PI) % (Math.PI * 2)) - Math.PI);
+                if (angleDiff > 0.5) {
+                    const x = Math.round(cx + Math.cos(angle) * ring);
+                    const y = Math.round(cy + Math.sin(angle) * ring);
+                    if (x >= 0 && x < w && y >= 0 && y < h) {
+                        mapComp.setWalkable(x, y, false);
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ============================================
+// Initialize
+// ============================================
+
+Core.create({ debug: false });
+const demoScene = new AStarDemoScene();
+Core.setScene(demoScene);
+
+// Expose scene for DemoPlayground scene switching
+window.__demoScene = demoScene;
+
+let lastTime = performance.now();
+
+function gameLoop() {
+    const now = performance.now();
+    const dt = Math.min((now - lastTime) / 1000, 0.1);
+    lastTime = now;
+    Core.update(dt);
+    requestAnimationFrame(gameLoop);
+}
+
+gameLoop();`;
+
+This is an interactive A* grid pathfinding demo implemented with **ECS architecture**.
+
+Click **Run** to start the simulation, use toolbar to switch map scenes, adjust parameters to observe pathfinding effects.
+
+<DemoPlayground
+    client:load
+    title="A* Pathfinding - ECS Architecture"
+    code={astarDemoCode}
+    canvasWidth={580}
+    canvasHeight={380}
+    scenes={astarScenes}
+    params={astarParams}
+/>
+
+<script is:inline src="/esengine/js/esengine.iife.js"></script>
+
+## Scene Descriptions
+
+- **Maze** - Maze generated using recursive division, tests long path finding
+- **Random Obstacles** - Randomly distributed obstacles with adjustable density
+- **Rooms** - Simulates room layouts, tests doors and corridors
+- **Spiral** - Spiral-shaped obstacles, tests complex paths
+
+## Related Documentation
+
+- [Pathfinding System API](/esengine/en/modules/pathfinding) - Complete API documentation and usage guide
+- [ORCA Local Avoidance](/esengine/en/modules/pathfinding/local-avoidance) - Multi-agent avoidance
+- [Getting Started](/esengine/en/guide/getting-started) - ECS framework introduction

--- a/docs/src/content/docs/en/examples/hpa-pathfinding-demo.mdx
+++ b/docs/src/content/docs/en/examples/hpa-pathfinding-demo.mdx
@@ -1,0 +1,452 @@
+---
+title: "HPA* Hierarchical Pathfinding"
+description: "Hierarchical Pathfinding A* demo, optimized for very large maps"
+---
+
+import DemoPlayground from '../../../../components/DemoPlayground.vue';
+
+export const hpaScenes = [
+    { id: 'small', label: 'S', name: 'Small Map (100x65)' },
+    { id: 'medium', label: 'M', name: 'Medium Map (250x163)' },
+    { id: 'large', label: 'L', name: 'Large Map (500x325)' },
+    { id: 'huge', label: 'XL', name: 'Huge Map (1000x650)' }
+];
+
+export const hpaParams = [
+    { id: 'clusterSize', label: 'Cluster', desc: 'Cluster size (side length)', value: 64, min: 10, max: 100, step: 10 },
+    { id: 'obstacleRate', label: 'Obstacles', desc: 'Obstacle density (%)', value: 15, min: 0, max: 100, step: 1 },
+    { id: 'showClusters', label: 'Clusters', desc: 'Show cluster boundaries (0=no, 1=yes)', value: 1, min: 0, max: 1, step: 1 }
+];
+
+export const hpaDemoCode = `// HPA* Hierarchical Pathfinding Demo
+// ============================================
+// Compare HPA* vs standard A* performance on large maps
+
+const {
+    GridMap, createGridMap,
+    AStarPathfinder, HPAPathfinder,
+    octileDistance
+} = ESEngine;
+
+const WIDTH = 580, HEIGHT = 380;
+
+const params = window.__demoParams || {
+    clusterSize: 64, obstacleRate: 15, showClusters: 1
+};
+
+let gridMap = null;
+let mapWidth = 100, mapHeight = 65;
+let startPos = { x: 5, y: 5 };
+let endPos = { x: 0, y: 0 };
+
+// Performance results
+let results = {
+    astar: { time: 0, nodes: 0, pathLen: 0, path: [] },
+    hpa: { time: 0, nodes: 0, pathLen: 0, path: [], stats: null, preprocessTime: 0, cachedTime: 0 }
+};
+
+let hpaPathfinder = null;
+let isSearching = false;
+
+// ============================================
+// Rendering
+// ============================================
+
+function render(ctx) {
+    if (!gridMap) return;
+
+    const cellW = WIDTH / mapWidth;
+    const cellH = HEIGHT / mapHeight;
+    const drawCells = cellW >= 2;  // Only draw cells when they are large enough
+
+    // Clear screen
+    ctx.fillStyle = '#16213e';
+    ctx.fillRect(0, 0, WIDTH, HEIGHT);
+
+    // Draw cluster boundaries
+    if (params.showClusters === 1) {
+        ctx.strokeStyle = 'rgba(100, 200, 255, 0.4)';
+        ctx.lineWidth = 1;
+        const cs = params.clusterSize;
+        for (let cx = 0; cx <= Math.ceil(mapWidth / cs); cx++) {
+            const x = cx * cs * cellW;
+            ctx.beginPath();
+            ctx.moveTo(x, 0);
+            ctx.lineTo(x, HEIGHT);
+            ctx.stroke();
+        }
+        for (let cy = 0; cy <= Math.ceil(mapHeight / cs); cy++) {
+            const y = cy * cs * cellH;
+            ctx.beginPath();
+            ctx.moveTo(0, y);
+            ctx.lineTo(WIDTH, y);
+            ctx.stroke();
+        }
+    }
+
+    // Draw obstacles (only when cells are large enough)
+    if (drawCells) {
+        ctx.fillStyle = '#2d4263';
+        for (let y = 0; y < mapHeight; y++) {
+            for (let x = 0; x < mapWidth; x++) {
+                if (!gridMap.isWalkable(x, y)) {
+                    ctx.fillRect(x * cellW, y * cellH, cellW - 0.5, cellH - 0.5);
+                }
+            }
+        }
+    } else {
+        // Large map: use sampling
+        ctx.fillStyle = '#2d4263';
+        const sampleRate = Math.ceil(mapWidth / WIDTH * 2);
+        for (let sy = 0; sy < HEIGHT; sy += 2) {
+            for (let sx = 0; sx < WIDTH; sx += 2) {
+                const gx = Math.floor(sx / cellW);
+                const gy = Math.floor(sy / cellH);
+                if (gx < mapWidth && gy < mapHeight && !gridMap.isWalkable(gx, gy)) {
+                    ctx.fillRect(sx, sy, 2, 2);
+                }
+            }
+        }
+    }
+
+    // Draw A* path
+    if (results.astar.path.length > 1) {
+        ctx.strokeStyle = 'rgba(255, 107, 107, 0.7)';
+        ctx.lineWidth = drawCells ? 2 : 3;
+        ctx.beginPath();
+        ctx.moveTo(results.astar.path[0].x * cellW + cellW/2, results.astar.path[0].y * cellH + cellH/2);
+        for (let i = 1; i < results.astar.path.length; i++) {
+            ctx.lineTo(results.astar.path[i].x * cellW + cellW/2, results.astar.path[i].y * cellH + cellH/2);
+        }
+        ctx.stroke();
+    }
+
+    // Draw HPA* path
+    if (results.hpa.path.length > 1) {
+        ctx.strokeStyle = 'rgba(78, 205, 196, 0.9)';
+        ctx.lineWidth = drawCells ? 3 : 4;
+        ctx.beginPath();
+        ctx.moveTo(results.hpa.path[0].x * cellW + cellW/2, results.hpa.path[0].y * cellH + cellH/2);
+        for (let i = 1; i < results.hpa.path.length; i++) {
+            ctx.lineTo(results.hpa.path[i].x * cellW + cellW/2, results.hpa.path[i].y * cellH + cellH/2);
+        }
+        ctx.stroke();
+    }
+
+    // Draw start and end
+    const pointSize = Math.max(4, Math.min(cellW, cellH) * 0.5);
+    ctx.fillStyle = '#00d4ff';
+    ctx.beginPath();
+    ctx.arc(startPos.x * cellW + cellW/2, startPos.y * cellH + cellH/2, pointSize, 0, Math.PI * 2);
+    ctx.fill();
+
+    ctx.fillStyle = '#ff6b6b';
+    ctx.beginPath();
+    ctx.arc(endPos.x * cellW + cellW/2, endPos.y * cellH + cellH/2, pointSize, 0, Math.PI * 2);
+    ctx.fill();
+
+    // HUD - Performance comparison
+    const panelX = 5, panelY = 5;
+    ctx.fillStyle = 'rgba(0,0,0,0.85)';
+    ctx.fillRect(panelX, panelY, 240, 155);
+
+    ctx.font = 'bold 11px monospace';
+    ctx.fillStyle = '#fff';
+    ctx.fillText('HPA* vs A* Performance', panelX + 5, panelY + 15);
+
+    ctx.font = '10px monospace';
+    ctx.fillStyle = '#888';
+    const totalCells = (mapWidth * mapHeight / 1000).toFixed(0);
+    ctx.fillText(\`Map: \${mapWidth}x\${mapHeight} (\${totalCells}K cells)\`, panelX + 5, panelY + 30);
+
+    // A* results
+    ctx.fillStyle = '#ff6b6b';
+    ctx.fillText('Standard A*:', panelX + 5, panelY + 47);
+    ctx.fillStyle = '#ccc';
+    if (results.astar.time > 0) {
+        ctx.fillText(\`  Time: \${results.astar.time.toFixed(2)}ms\`, panelX + 5, panelY + 60);
+        ctx.fillText(\`  Nodes: \${results.astar.nodes.toLocaleString()}\`, panelX + 5, panelY + 72);
+    } else {
+        ctx.fillText('  (searching...)', panelX + 5, panelY + 60);
+    }
+
+    // HPA* results
+    ctx.fillStyle = '#4ecdc4';
+    ctx.fillText('HPA* (Lazy Intra-Edges):', panelX + 5, panelY + 87);
+    ctx.fillStyle = '#ccc';
+    if (results.hpa.time > 0) {
+        ctx.fillText(\`  Preprocess: \${results.hpa.preprocessTime.toFixed(1)}ms\`, panelX + 5, panelY + 100);
+        ctx.fillText(\`  1st Query: \${results.hpa.time.toFixed(2)}ms\`, panelX + 5, panelY + 112);
+        if (results.hpa.cachedTime > 0) {
+            ctx.fillText(\`  Cached: \${results.hpa.cachedTime.toFixed(2)}ms\`, panelX + 5, panelY + 124);
+        }
+        if (results.hpa.stats) {
+            ctx.fillText(\`  Clusters: \${results.hpa.stats.clusters}, Nodes: \${results.hpa.stats.abstractNodes}\`, panelX + 5, panelY + 136);
+        }
+    } else {
+        ctx.fillText('  (searching...)', panelX + 5, panelY + 100);
+    }
+
+    // Speedup indicator
+    if (results.astar.time > 0 && results.hpa.cachedTime > 0) {
+        const speedup = results.astar.time / results.hpa.cachedTime;
+        ctx.fillStyle = speedup > 1 ? '#4ecdc4' : '#ff6b6b';
+        ctx.font = 'bold 12px monospace';
+        ctx.fillText(\`Speedup (cached): \${speedup.toFixed(0)}x\`, panelX + 5, panelY + 151);
+    }
+
+    // Legend
+    const legendX = WIDTH - 90, legendY = 5;
+    ctx.fillStyle = 'rgba(0,0,0,0.85)';
+    ctx.fillRect(legendX, legendY, 85, 55);
+    ctx.font = '9px monospace';
+
+    ctx.fillStyle = '#ff6b6b';
+    ctx.fillRect(legendX + 5, legendY + 10, 15, 3);
+    ctx.fillStyle = '#fff';
+    ctx.fillText('A*', legendX + 25, legendY + 15);
+
+    ctx.fillStyle = '#4ecdc4';
+    ctx.fillRect(legendX + 5, legendY + 25, 15, 3);
+    ctx.fillStyle = '#fff';
+    ctx.fillText('HPA*', legendX + 25, legendY + 30);
+
+    ctx.fillStyle = 'rgba(100, 200, 255, 0.5)';
+    ctx.fillRect(legendX + 5, legendY + 40, 15, 3);
+    ctx.fillStyle = '#fff';
+    ctx.fillText('Cluster', legendX + 25, legendY + 45);
+
+    // Large map hint
+    if (!drawCells) {
+        ctx.fillStyle = 'rgba(0,0,0,0.7)';
+        ctx.fillRect(WIDTH/2 - 80, HEIGHT - 25, 160, 20);
+        ctx.fillStyle = '#888';
+        ctx.font = '10px monospace';
+        ctx.fillText('Large map: simplified view', WIDTH/2 - 70, HEIGHT - 10);
+    }
+}
+
+// ============================================
+// Pathfinding
+// ============================================
+
+async function runPathfinding() {
+    if (!gridMap || isSearching) return;
+    isSearching = true;
+
+    // Reset results
+    results.astar = { time: 0, nodes: 0, pathLen: 0, path: [] };
+    results.hpa = { time: 0, nodes: 0, pathLen: 0, path: [], stats: null, preprocessTime: 0, cachedTime: 0 };
+
+    // Adjust maxNodes based on map size to ensure complete search on large maps
+    const maxNodes = mapWidth * mapHeight;
+    const options = { allowDiagonal: true, heuristic: octileDistance, maxNodes };
+
+    // Delay to show UI update
+    await new Promise(r => setTimeout(r, 50));
+
+    // Standard A*
+    const astar = new AStarPathfinder(gridMap);
+    let t0 = performance.now();
+    let result = astar.findPath(startPos.x, startPos.y, endPos.x, endPos.y, options);
+    results.astar = {
+        time: performance.now() - t0,
+        nodes: result.nodesSearched,
+        pathLen: result.path.length,
+        path: result.path
+    };
+
+    await new Promise(r => setTimeout(r, 10));
+
+    // HPA* with lazy intra-edges (default)
+    hpaPathfinder = new HPAPathfinder(gridMap, {
+        clusterSize: params.clusterSize,
+        maxEntranceWidth: 16,
+        cacheInternalPaths: true,
+        lazyIntraEdges: true  // Lazy compute intra-edges
+    });
+
+    // Preprocess (now very fast because no real path computation)
+    t0 = performance.now();
+    hpaPathfinder.preprocess();
+    const preprocessTime = performance.now() - t0;
+
+    // First query (triggers lazy path computation)
+    t0 = performance.now();
+    result = hpaPathfinder.findPath(startPos.x, startPos.y, endPos.x, endPos.y, options);
+    const firstQueryTime = performance.now() - t0;
+
+    // Second query (uses cache, should be very fast)
+    t0 = performance.now();
+    hpaPathfinder.findPath(startPos.x, startPos.y, endPos.x, endPos.y, options);
+    const cachedTime = performance.now() - t0;
+
+    results.hpa = {
+        time: firstQueryTime,
+        nodes: result.nodesSearched,
+        pathLen: result.path.length,
+        path: result.path,
+        stats: hpaPathfinder.getStats(),
+        preprocessTime: preprocessTime,
+        cachedTime: cachedTime
+    };
+
+    isSearching = false;
+}
+
+// ============================================
+// Map Generation
+// ============================================
+
+function generateMap(size) {
+    const sizes = {
+        small: { w: 100, h: 65 },
+        medium: { w: 250, h: 163 },
+        large: { w: 500, h: 325 },
+        huge: { w: 1000, h: 650 }
+    };
+
+    const s = sizes[size] || sizes.small;
+    mapWidth = s.w;
+    mapHeight = s.h;
+
+    gridMap = createGridMap(mapWidth, mapHeight);
+    hpaPathfinder = null;
+
+    // Generate random obstacles
+    const rate = params.obstacleRate / 100;
+    for (let y = 0; y < mapHeight; y++) {
+        for (let x = 0; x < mapWidth; x++) {
+            if (Math.random() < rate) {
+                gridMap.setWalkable(x, y, false);
+            }
+        }
+    }
+
+    // Ensure start and end areas are clear
+    const clearRadius = Math.max(3, Math.floor(Math.min(mapWidth, mapHeight) / 20));
+    const clearArea = (cx, cy, r) => {
+        for (let dy = -r; dy <= r; dy++) {
+            for (let dx = -r; dx <= r; dx++) {
+                const x = cx + dx, y = cy + dy;
+                if (x >= 0 && x < mapWidth && y >= 0 && y < mapHeight) {
+                    gridMap.setWalkable(x, y, true);
+                }
+            }
+        }
+    };
+
+    startPos = { x: clearRadius + 2, y: clearRadius + 2 };
+    endPos = { x: mapWidth - clearRadius - 3, y: mapHeight - clearRadius - 3 };
+    clearArea(startPos.x, startPos.y, clearRadius);
+    clearArea(endPos.x, endPos.y, clearRadius);
+
+    // Reset results
+    results.astar = { time: 0, nodes: 0, pathLen: 0, path: [] };
+    results.hpa = { time: 0, nodes: 0, pathLen: 0, path: [], stats: null, preprocessTime: 0, cachedTime: 0 };
+
+    runPathfinding();
+}
+
+// ============================================
+// Initialize
+// ============================================
+
+generateMap('small');
+
+// Click to set start/end
+let clickMode = 'start';
+canvas.addEventListener('click', (e) => {
+    if (isSearching) return;
+
+    const rect = canvas.getBoundingClientRect();
+    const mx = (e.clientX - rect.left) * (canvas.width / rect.width);
+    const my = (e.clientY - rect.top) * (canvas.height / rect.height);
+    const cellW = WIDTH / mapWidth;
+    const cellH = HEIGHT / mapHeight;
+    const gx = Math.floor(mx / cellW);
+    const gy = Math.floor(my / cellH);
+
+    if (gx >= 0 && gx < mapWidth && gy >= 0 && gy < mapHeight && gridMap.isWalkable(gx, gy)) {
+        if (clickMode === 'start') {
+            startPos = { x: gx, y: gy };
+            clickMode = 'end';
+        } else {
+            endPos = { x: gx, y: gy };
+            clickMode = 'start';
+            runPathfinding();
+        }
+    }
+});
+
+// Scene switching
+window.__demoScene = {
+    loadScenario: (type) => {
+        generateMap(type);
+    }
+};
+
+// Game loop
+function gameLoop() {
+    render(ctx);
+    requestAnimationFrame(gameLoop);
+}
+
+gameLoop();`;
+
+This is an **HPA* (Hierarchical Pathfinding A*)** demo showing performance advantages on **very large maps**.
+
+Click **Run** to start, use the toolbar to switch between different map sizes and observe the performance comparison between HPA* and standard A*.
+
+**How HPA* Works:**
+1. Divide the map into **Clusters**
+2. Detect **Entrances** at cluster boundaries
+3. Build an **Abstract Graph** connecting entrances
+4. First find path on abstract graph, then refine to detailed path
+
+**Lazy Intra-Edges Optimization:**
+- Preprocessing is now ~1000x faster (52ms vs 68s for 1000x650 map)
+- First query computes actual paths on demand
+- Subsequent queries use cached paths (extremely fast)
+
+<DemoPlayground
+    client:load
+    title="HPA* Hierarchical Pathfinding - Large Map Optimization"
+    code={hpaDemoCode}
+    canvasWidth={580}
+    canvasHeight={380}
+    scenes={hpaScenes}
+    params={hpaParams}
+/>
+
+<script is:inline src="/esengine/js/esengine.iife.js"></script>
+
+## Performance Comparison
+
+| Map Size | Cell Count | A* Suitability | HPA* Advantage |
+|----------|------------|----------------|----------------|
+| 100x65 | ~6,500 | ✅ Good | Slight |
+| 250x163 | ~40,000 | ⚠️ Slow | Noticeable |
+| 500x325 | ~162,500 | ❌ Very slow | **Significant** |
+| 1000x650 | ~650,000 | ❌ Extremely slow | **Huge** |
+
+## Use Cases
+
+- **Open World Games** - Large continuous maps (e.g., 1000x1000+)
+- **RTS Games** - Many units requiring frequent pathfinding
+- **City Simulation** - Complex road networks
+- **Server-side Pathfinding** - Backend requiring fast responses
+
+## Parameter Description
+
+| Parameter | Description |
+|-----------|-------------|
+| **Cluster** | Cluster size, larger = faster preprocessing but lower precision |
+| **Obstacles** | Obstacle density |
+| **Clusters** | Whether to show cluster boundary lines |
+
+## Related Documentation
+
+- [Algorithm Comparison Demo](/esengine/en/examples/algorithm-comparison-demo) - Compare A*, Bidirectional A*, JPS
+- [Search Visualization](/esengine/en/examples/search-visualization-demo) - A* search process visualization
+- [Pathfinding System API](/esengine/en/modules/pathfinding) - Complete documentation

--- a/docs/src/content/docs/en/examples/index.md
+++ b/docs/src/content/docs/en/examples/index.md
@@ -5,17 +5,31 @@ description: "ESEngine example projects and demos"
 
 Explore example projects to learn ESEngine best practices.
 
-## Available Examples
+## Pathfinding Demos
 
-### [Worker System Demo](/en/examples/worker-system-demo/)
-Demonstrates how to use Web Workers for parallel processing, offloading heavy computations from the main thread.
+### [A* Pathfinding Demo](/en/examples/astar-pathfinding-demo/)
+Grid-based A* pathfinding visualization:
+- Maze generation, random obstacles, room layouts, spiral maps
+- Incremental pathfinding with time-slicing
+- ECS architecture demonstration
+
+### [Multi-Agent Pathfinding Demo](/en/examples/multi-agent-pathfinding-demo/)
+Multiple agents pathfinding simultaneously with avoidance:
+- A* pathfinding + ORCA avoidance combined
+- Multiple scenario presets (swap, gather, scatter, patrol)
+- PathfindingSystem and LocalAvoidanceSystem cooperation
 
 ### [ORCA Local Avoidance Demo](/en/examples/orca-avoidance-demo/)
 Interactive multi-agent collision avoidance using ORCA algorithm:
 - KDTree spatial indexing for efficient neighbor queries
 - Linear programming solver for velocity optimization
 - Multiple scenario presets (circle swap, crossroads, funnel)
-- Real-time parameter adjustment
+- Support for 50-500 agents with real-time parameter adjustment
+
+## System Demos
+
+### [Worker System Demo](/en/examples/worker-system-demo/)
+Demonstrates how to use Web Workers for parallel processing, offloading heavy computations from the main thread.
 
 ## External Examples
 

--- a/docs/src/content/docs/en/examples/multi-agent-pathfinding-demo.mdx
+++ b/docs/src/content/docs/en/examples/multi-agent-pathfinding-demo.mdx
@@ -1,0 +1,510 @@
+---
+title: "Multi-Agent Pathfinding Demo"
+description: "Interactive multi-agent pathfinding and avoidance demo using ECS architecture"
+---
+
+import DemoPlayground from '../../../../components/DemoPlayground.vue';
+
+export const multiAgentScenes = [
+    { id: 'swap', label: '⇄', name: 'Swap Positions' },
+    { id: 'gather', label: '◉', name: 'Gather' },
+    { id: 'scatter', label: '✦', name: 'Scatter' },
+    { id: 'patrol', label: '↻', name: 'Patrol' }
+];
+
+export const multiAgentParams = [
+    { id: 'agentCount', label: 'Agents', desc: 'Number of agents', value: 8, min: 2, max: 20, step: 2 },
+    { id: 'speed', label: 'Speed', desc: 'Movement speed (grids/sec)', value: 5, min: 1, max: 15, step: 1 },
+    { id: 'avoidance', label: 'Avoidance', desc: 'Enable local avoidance (0=no, 1=yes)', value: 1, min: 0, max: 1, step: 1 },
+    { id: 'gridSize', label: 'Grid', desc: 'Grid size', value: 30, min: 20, max: 50, step: 5 }
+];
+
+export const multiAgentDemoCode = `// Multi-Agent Pathfinding - ECS Architecture Demo
+// ============================================
+// Shows multiple agents pathfinding simultaneously with ORCA avoidance
+
+const {
+    Core, Scene, Component, EntitySystem, Matcher, Time,
+    ECSComponent, ECSSystem,
+    PathfindingAgentComponent, PathfindingMapComponent, PathfindingSystem,
+    AvoidanceAgentComponent, AvoidanceWorldComponent, LocalAvoidanceSystem
+} = ESEngine;
+
+const WIDTH = 580, HEIGHT = 380;
+
+const params = window.__demoParams || {
+    agentCount: 8, speed: 5, avoidance: 1, gridSize: 30
+};
+
+// Avoidance world component reference
+let worldComponent: any = null;
+
+// ============================================
+// Component Definitions
+// ============================================
+
+@ECSComponent('AgentVisual')
+class AgentVisualComponent extends Component {
+    color = '#00d4ff';
+    targetColor = '#ff6b6b';
+    index = 0;
+}
+
+// ============================================
+// Render System
+// ============================================
+
+@ECSSystem('Render', { updateOrder: 100 })
+class RenderSystem extends EntitySystem {
+    ctx: CanvasRenderingContext2D;
+    mapComp: PathfindingMapComponent | null = null;
+    fps = 0; frameCount = 0; lastFpsTime = 0;
+
+    constructor(context: CanvasRenderingContext2D) {
+        super(Matcher.all(PathfindingAgentComponent, AgentVisualComponent));
+        this.ctx = context;
+    }
+
+    process(entities) {
+        const ctx = this.ctx;
+
+        // Clear screen
+        ctx.fillStyle = '#16213e';
+        ctx.fillRect(0, 0, WIDTH, HEIGHT);
+
+        // Find map component
+        if (!this.mapComp) {
+            const mapEntities = this.scene.entities.findEntitiesWithComponent(PathfindingMapComponent);
+            if (mapEntities.length > 0) {
+                this.mapComp = mapEntities[0].getComponent(PathfindingMapComponent);
+            }
+        }
+
+        const map = this.mapComp?.map;
+        if (!map) return;
+
+        const cellW = WIDTH / map.width;
+        const cellH = HEIGHT / map.height;
+
+        // Draw obstacles
+        ctx.fillStyle = '#2d4263';
+        for (let y = 0; y < map.height; y++) {
+            for (let x = 0; x < map.width; x++) {
+                if (!map.isWalkable(x, y)) {
+                    ctx.fillRect(x * cellW + 1, y * cellH + 1, cellW - 2, cellH - 2);
+                }
+            }
+        }
+
+        // FPS
+        this.frameCount++;
+        const now = performance.now();
+        if (now - this.lastFpsTime >= 1000) {
+            this.fps = this.frameCount;
+            this.frameCount = 0;
+            this.lastFpsTime = now;
+        }
+
+        // Draw agents (note: agent.x/y are now pixel coordinates)
+        for (const entity of entities) {
+            const agent = entity.getComponent(PathfindingAgentComponent);
+            const visual = entity.getComponent(AgentVisualComponent);
+
+            // Draw path (path points are grid coords, need conversion)
+            if (agent.path.length > agent.pathIndex) {
+                ctx.strokeStyle = visual.color + '40';
+                ctx.lineWidth = 2;
+                ctx.beginPath();
+                ctx.moveTo(agent.x, agent.y);  // agent.x/y already pixel coords
+                for (let i = agent.pathIndex; i < agent.path.length; i++) {
+                    const p = agent.path[i];
+                    ctx.lineTo(p.x * cellW + cellW/2, p.y * cellH + cellH/2);
+                }
+                ctx.stroke();
+            }
+
+            // Draw target (targetX/Y are grid coords)
+            ctx.fillStyle = visual.targetColor + '60';
+            ctx.beginPath();
+            ctx.arc(agent.targetX * cellW + cellW/2, agent.targetY * cellH + cellH/2, 5, 0, Math.PI * 2);
+            ctx.fill();
+
+            // Draw agent (agent.x/y are pixel coords)
+            const x = agent.x;
+            const y = agent.y;
+
+            // Glow
+            const gradient = ctx.createRadialGradient(x, y, 0, x, y, 15);
+            gradient.addColorStop(0, visual.color);
+            gradient.addColorStop(1, 'transparent');
+            ctx.beginPath();
+            ctx.arc(x, y, 15, 0, Math.PI * 2);
+            ctx.fillStyle = gradient;
+            ctx.fill();
+
+            // Agent
+            ctx.beginPath();
+            ctx.arc(x, y, 7, 0, Math.PI * 2);
+            ctx.fillStyle = visual.color;
+            ctx.fill();
+
+            // Number
+            ctx.fillStyle = '#fff';
+            ctx.font = '10px monospace';
+            ctx.textAlign = 'center';
+            ctx.fillText(String(visual.index + 1), x, y + 3);
+        }
+
+        // HUD
+        ctx.fillStyle = 'rgba(0,0,0,0.6)';
+        ctx.fillRect(5, 5, 150, 50);
+        ctx.fillStyle = '#00d4ff';
+        ctx.font = '11px monospace';
+        ctx.textAlign = 'left';
+        ctx.fillText(\`Agents: \${entities.length}\`, 10, 20);
+        ctx.fillText(\`Avoidance: \${params.avoidance ? 'ON' : 'OFF'}\`, 10, 32);
+        ctx.fillText(\`FPS: \${this.fps}\`, 10, 44);
+    }
+}
+
+// ============================================
+// Preferred Velocity System (runs before LocalAvoidanceSystem)
+// Resets and sets preferred velocity towards next waypoint each frame
+// Required because LocalAvoidanceSystem only auto-sets when preferredVelocity=0
+// ============================================
+
+@ECSSystem('PreferredVelocity', { updateOrder: 45 })
+class PreferredVelocitySystem extends EntitySystem {
+    constructor() {
+        super(Matcher.all(PathfindingAgentComponent, AvoidanceAgentComponent));
+    }
+
+    process(entities) {
+        for (const entity of entities) {
+            const agent = entity.getComponent(PathfindingAgentComponent);
+            const avoid = entity.getComponent(AvoidanceAgentComponent);
+
+            // Sync position first (LocalAvoidanceSystem syncs later, need to sync here first)
+            avoid.positionX = agent.x;
+            avoid.positionY = agent.y;
+
+            // Reset preferred velocity
+            avoid.preferredVelocityX = 0;
+            avoid.preferredVelocityY = 0;
+
+            // If has valid path, set preferred velocity towards next waypoint
+            if (agent.hasValidPath() && !agent.isPathComplete()) {
+                const waypoint = agent.getNextWaypoint();
+                if (waypoint) {
+                    // Calculate direction and multiply by maxSpeed directly
+                    // Don't use setPreferredVelocityTowards as it slows down based on distance
+                    const dx = waypoint.x - agent.x;
+                    const dy = waypoint.y - agent.y;
+                    const dist = Math.sqrt(dx * dx + dy * dy);
+                    if (dist > 0.001) {
+                        avoid.preferredVelocityX = (dx / dist) * avoid.maxSpeed;
+                        avoid.preferredVelocityY = (dy / dist) * avoid.maxSpeed;
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ============================================
+// Movement System
+// All coordinates use grid units (consistent with PathfindingSystem and LocalAvoidanceSystem)
+// ============================================
+
+@ECSSystem('Movement', { updateOrder: 60 })
+class MovementSystem extends EntitySystem {
+    constructor() {
+        super(Matcher.all(PathfindingAgentComponent));
+    }
+
+    process(entities) {
+        const dt = Time.deltaTime;
+
+        for (const entity of entities) {
+            const agent = entity.getComponent(PathfindingAgentComponent);
+            const avoid = entity.getComponent(AvoidanceAgentComponent);
+
+            // Wait for path calculation
+            if (!agent.hasValidPath() || agent.isPathComplete()) {
+                if (avoid) avoid.stop();
+                continue;
+            }
+
+            const waypoint = agent.getNextWaypoint();
+            if (!waypoint) continue;
+
+            // If avoidance enabled, use ORCA computed velocity (grid units/sec)
+            if (params.avoidance && avoid) {
+                agent.x += avoid.velocityX * dt;
+                agent.y += avoid.velocityY * dt;
+            } else {
+                // Direct movement to target (grid coords)
+                const dx = waypoint.x - agent.x;
+                const dy = waypoint.y - agent.y;
+                const dist = Math.sqrt(dx * dx + dy * dy);
+                const moveSpeed = params.speed * dt;  // speed is grids/sec
+
+                if (dist < 0.1) {
+                    agent.x = waypoint.x;
+                    agent.y = waypoint.y;
+                } else {
+                    agent.x += (dx / dist) * Math.min(moveSpeed, dist);
+                    agent.y += (dy / dist) * Math.min(moveSpeed, dist);
+                }
+            }
+
+            // Check if reached waypoint (grid distance)
+            const dx = waypoint.x - agent.x;
+            const dy = waypoint.y - agent.y;
+            if (Math.sqrt(dx * dx + dy * dy) < 0.5) {
+                agent.advanceWaypoint();
+            }
+        }
+    }
+}
+
+// ============================================
+// Scene
+// ============================================
+
+class MultiAgentDemoScene extends Scene {
+    mapEntity: any = null;
+    worldEntity: any = null;
+    agents: any[] = [];
+
+    initialize() {
+        this.name = 'MultiAgentDemo';
+
+        // Create avoidance world entity first (must be before addSystem)
+        if (params.avoidance) {
+            this.worldEntity = this.createEntity('AvoidanceWorld');
+            worldComponent = this.worldEntity.addComponent(new AvoidanceWorldComponent());
+        }
+
+        this.addSystem(new PathfindingSystem());       // order 0: calculate paths
+        if (params.avoidance) {
+            this.addSystem(new PreferredVelocitySystem()); // order 45: set preferred velocity
+            this.addSystem(new LocalAvoidanceSystem());    // order 50: ORCA computation
+        }
+        this.addSystem(new MovementSystem());          // order 60: apply velocity
+        this.addSystem(new RenderSystem(ctx));         // order 100: render
+    }
+
+    onStart() {
+        this.loadScenario('swap');
+    }
+
+    loadScenario(type: string) {
+        console.log('loadScenario called:', type);
+
+        // Clear (use correct API)
+        if (this.mapEntity) {
+            this.mapEntity.destroy();
+            this.mapEntity = null;
+        }
+        for (const agent of this.agents) {
+            agent.destroy();
+        }
+        this.agents = [];
+
+        // Reset system's map reference
+        for (const system of this.systems) {
+            if (system.mapComp) system.mapComp = null;
+        }
+
+        const gridSize = params.gridSize;
+        const gridH = Math.floor(gridSize * HEIGHT / WIDTH);
+
+        // Create map
+        this.mapEntity = this.createEntity('Map');
+        const mapComp = this.mapEntity.addComponent(new PathfindingMapComponent());
+        mapComp.width = gridSize;
+        mapComp.height = gridH;
+        mapComp.allowDiagonal = true;
+        mapComp.avoidCorners = true;
+        mapComp.enableSmoothing = false;
+
+        setTimeout(() => {
+            if (!mapComp.map) return;
+
+            // Generate obstacles
+            this.generateObstacles(mapComp);
+
+            const cellW = WIDTH / mapComp.width;
+            const cellH = HEIGHT / mapComp.height;
+            const count = params.agentCount;
+            const colors = [
+                '#00d4ff', '#ff6b6b', '#4ecdc4', '#ffe66d',
+                '#a29bfe', '#fd79a8', '#55efc4', '#ffeaa7',
+                '#74b9ff', '#ff7675', '#00b894', '#e17055'
+            ];
+
+            const scenarios = {
+                swap: () => {
+                    // Left-right swap
+                    for (let i = 0; i < count; i++) {
+                        const isLeft = i % 2 === 0;
+                        const row = Math.floor(i / 2);
+                        const startX = isLeft ? 2 : mapComp.width - 3;
+                        const startY = 3 + row * 3;
+                        const endX = isLeft ? mapComp.width - 3 : 2;
+                        const endY = startY;
+                        this.createAgent(startX, startY, endX, endY, colors[i % colors.length], i);
+                    }
+                },
+                gather: () => {
+                    // Gather from edges to center
+                    const cx = Math.floor(mapComp.width / 2);
+                    const cy = Math.floor(mapComp.height / 2);
+                    for (let i = 0; i < count; i++) {
+                        const angle = (i / count) * Math.PI * 2;
+                        const radius = Math.min(mapComp.width, mapComp.height) / 2 - 3;
+                        const startX = Math.round(cx + Math.cos(angle) * radius);
+                        const startY = Math.round(cy + Math.sin(angle) * radius);
+                        this.createAgent(startX, startY, cx, cy, colors[i % colors.length], i);
+                    }
+                },
+                scatter: () => {
+                    // Scatter from center to edges
+                    const cx = Math.floor(mapComp.width / 2);
+                    const cy = Math.floor(mapComp.height / 2);
+                    for (let i = 0; i < count; i++) {
+                        const angle = (i / count) * Math.PI * 2;
+                        const radius = Math.min(mapComp.width, mapComp.height) / 2 - 3;
+                        const endX = Math.round(cx + Math.cos(angle) * radius);
+                        const endY = Math.round(cy + Math.sin(angle) * radius);
+                        this.createAgent(cx + (i % 3) - 1, cy + Math.floor(i / 3) - 1, endX, endY, colors[i % colors.length], i);
+                    }
+                },
+                patrol: () => {
+                    // Patrol routes
+                    for (let i = 0; i < count; i++) {
+                        const startX = 2 + (i % 4) * 7;
+                        const startY = 2 + Math.floor(i / 4) * 7;
+                        const endX = mapComp.width - 3 - (i % 4) * 5;
+                        const endY = mapComp.height - 3 - Math.floor(i / 4) * 5;
+                        this.createAgent(startX, startY, endX, endY, colors[i % colors.length], i);
+                    }
+                }
+            };
+
+            scenarios[type]?.();
+        }, 100);
+    }
+
+    generateObstacles(mapComp) {
+        const w = mapComp.width, h = mapComp.height;
+
+        // Clear old ORCA obstacles
+        if (worldComponent) {
+            worldComponent.clearObstacles();
+        }
+
+        // Add random obstacles
+        for (let i = 0; i < 15; i++) {
+            const ox = 5 + Math.floor(Math.random() * (w - 10));
+            const oy = 3 + Math.floor(Math.random() * (h - 6));
+            const ow = 1 + Math.floor(Math.random() * 3);
+            const oh = 1 + Math.floor(Math.random() * 3);
+
+            // Set pathfinding map obstacle
+            mapComp.setRectWalkable(ox, oy, ow, oh, false);
+
+            // Also add to ORCA avoidance system (grid coords, CW order = math CCW)
+            if (worldComponent) {
+                worldComponent.addObstacle({
+                    vertices: [
+                        { x: ox, y: oy },              // top-left
+                        { x: ox + ow, y: oy },         // top-right
+                        { x: ox + ow, y: oy + oh },    // bottom-right
+                        { x: ox, y: oy + oh }          // bottom-left
+                    ]
+                });
+            }
+        }
+    }
+
+    createAgent(sx, sy, ex, ey, color, index) {
+        const entity = this.createEntity('Agent' + index);
+
+        // agent.x/y use grid coordinates (consistent with PathfindingSystem and LocalAvoidanceSystem)
+        const agent = entity.addComponent(new PathfindingAgentComponent());
+        agent.x = sx;
+        agent.y = sy;
+        agent.requestPathTo(ex, ey);
+
+        if (params.avoidance) {
+            const avoid = entity.addComponent(new AvoidanceAgentComponent());
+            // All parameters use grid units!
+            // LocalAvoidanceSystem auto-syncs position from agent.x/y
+            avoid.radius = 0.4;              // grid units (about 0.4 cells radius)
+            avoid.maxSpeed = params.speed;   // grids/sec
+            avoid.neighborDist = 3;          // grid units (detect neighbors within 3 cells)
+            avoid.timeHorizon = 1.5;
+            avoid.autoApplyVelocity = true;  // auto-apply newVelocity to velocity
+        }
+
+        const visual = entity.addComponent(new AgentVisualComponent());
+        visual.color = color;
+        visual.index = index;
+
+        this.agents.push(entity);
+    }
+}
+
+// ============================================
+// Initialize
+// ============================================
+
+Core.create({ debug: false });
+const demoScene = new MultiAgentDemoScene();
+Core.setScene(demoScene);
+
+// Expose scene for DemoPlayground scene switching
+window.__demoScene = demoScene;
+
+let lastTime = performance.now();
+
+function gameLoop() {
+    const now = performance.now();
+    const dt = Math.min((now - lastTime) / 1000, 0.1);
+    lastTime = now;
+    Core.update(dt);
+    requestAnimationFrame(gameLoop);
+}
+
+gameLoop();`;
+
+This is an interactive multi-agent pathfinding and avoidance demo implemented with **ECS architecture**, combining **A* pathfinding** and **ORCA local avoidance**.
+
+Click **Run** to start the simulation, use toolbar to switch scenes, disable Avoidance parameter to observe collision effects without avoidance.
+
+<DemoPlayground
+    client:load
+    title="Multi-Agent Pathfinding - ECS Architecture"
+    code={multiAgentDemoCode}
+    canvasWidth={580}
+    canvasHeight={380}
+    scenes={multiAgentScenes}
+    params={multiAgentParams}
+/>
+
+<script is:inline src="/esengine/js/esengine.iife.js"></script>
+
+## Scene Descriptions
+
+- **Swap Positions** - Agents swap from left and right sides, tests head-on avoidance
+- **Gather** - Gather from edges to center, tests multi-agent convergence
+- **Scatter** - Scatter from center to edges, tests fan-shaped avoidance
+- **Patrol** - Multiple agents patrolling, tests random encounter avoidance
+
+## Related Documentation
+
+- [Pathfinding System API](/esengine/en/modules/pathfinding) - A* pathfinding documentation
+- [ORCA Local Avoidance](/esengine/en/modules/pathfinding/local-avoidance) - Multi-agent avoidance
+- [Getting Started](/esengine/en/guide/getting-started) - ECS framework introduction

--- a/docs/src/content/docs/en/examples/orca-avoidance-demo.mdx
+++ b/docs/src/content/docs/en/examples/orca-avoidance-demo.mdx
@@ -22,11 +22,12 @@ export const orcaParams = [
 export const orcaDemoCode = `// ORCA Local Avoidance - ECS Architecture Demo
 // ============================================
 // Use toolbar buttons to switch scenes, use parameter panel to adjust settings
+// Left-click canvas to add agent, right-click to place obstacle
 
 const {
     Core, Scene, Component, EntitySystem, Matcher, Time,
     ECSComponent, ECSSystem,
-    AvoidanceAgentComponent, LocalAvoidanceSystem
+    AvoidanceAgentComponent, AvoidanceWorldComponent, LocalAvoidanceSystem
 } = ESEngine;
 
 const WIDTH = 580, HEIGHT = 380;
@@ -36,6 +37,9 @@ const CX = WIDTH / 2, CY = HEIGHT / 2;
 const params = window.__demoParams || {
     agentCount: 40, maxSpeed: 90, radius: 3, neighborDist: 70
 };
+
+// Avoidance world component reference (for adding obstacles)
+let worldComponent: any = null;
 
 // ============================================
 // Component Definitions
@@ -99,6 +103,24 @@ class RenderSystem extends EntitySystem {
         this.ctx.fillStyle = 'rgba(22, 33, 62, 0.3)';
         this.ctx.fillRect(0, 0, WIDTH, HEIGHT);
 
+        // Draw obstacles
+        this.ctx.fillStyle = '#2d4263';
+        if (worldComponent) {
+            for (const obs of worldComponent.obstacles) {
+                // Obstacles stored as vertex lists, draw as polygons
+                const v = obs.vertices;
+                if (v.length >= 3) {
+                    this.ctx.beginPath();
+                    this.ctx.moveTo(v[0].x, v[0].y);
+                    for (let i = 1; i < v.length; i++) {
+                        this.ctx.lineTo(v[i].x, v[i].y);
+                    }
+                    this.ctx.closePath();
+                    this.ctx.fill();
+                }
+            }
+        }
+
         // FPS calculation
         this.frameCount++;
         const now = performance.now();
@@ -150,11 +172,14 @@ class RenderSystem extends EntitySystem {
 
         // HUD
         this.ctx.fillStyle = 'rgba(0,0,0,0.6)';
-        this.ctx.fillRect(5, 5, 120, 35);
+        this.ctx.fillRect(5, 5, 150, 58);
         this.ctx.fillStyle = '#00d4ff';
         this.ctx.font = '11px monospace';
         this.ctx.fillText(\`Agents: \${entities.length}\`, 10, 20);
-        this.ctx.fillText(\`FPS: \${this.fps}\`, 10, 32);
+        this.ctx.fillText(\`Obstacles: \${worldComponent?.obstacles.length || 0}\`, 10, 32);
+        this.ctx.fillText(\`FPS: \${this.fps}\`, 10, 44);
+        this.ctx.fillStyle = '#888';
+        this.ctx.fillText('Left:Add Right:Obstacle', 10, 55);
     }
 }
 
@@ -163,20 +188,36 @@ class RenderSystem extends EntitySystem {
 // ============================================
 
 class ORCADemoScene extends Scene {
+    worldEntity: any = null;
+
     initialize() {
         this.name = 'ORCADemo';
+
+        // Create avoidance world entity first (must be before addSystem so LocalAvoidanceSystem can find it)
+        this.worldEntity = this.createEntity('AvoidanceWorld');
+        worldComponent = this.worldEntity.addComponent(new AvoidanceWorldComponent());
+
         this.addSystem(new TargetFollowSystem());
         this.addSystem(new LocalAvoidanceSystem());
         this.addSystem(new MovementSystem());
         this.addSystem(new RenderSystem(ctx));
     }
 
-    onStart() { this.loadScenario('circle'); }
+    onStart() {
+        this.loadScenario('circle');
+    }
 
     loadScenario(type: string) {
-        // Clear existing entities
+        console.log('loadScenario called:', type);
+
+        // Clear existing agent entities
         const result = this.queryAll(AvoidanceAgentComponent);
         this.destroyEntities([...result.entities]);
+
+        // Clear obstacles
+        if (worldComponent) {
+            worldComponent.clearObstacles();
+        }
 
         const count = params.agentCount;
         const configs = {
@@ -247,6 +288,41 @@ Core.create({ debug: false });
 const demoScene = new ORCADemoScene();
 Core.setScene(demoScene);
 
+// Expose scene for DemoPlayground
+window.__demoScene = demoScene;
+
+// Mouse event handling
+canvas.addEventListener('click', (e: MouseEvent) => {
+    const rect = canvas.getBoundingClientRect();
+    const x = (e.clientX - rect.left) * (canvas.width / rect.width);
+    const y = (e.clientY - rect.top) * (canvas.height / rect.height);
+
+    // Left click adds agent
+    const color = \`hsl(\${Math.random() * 360}, 80%, 60%)\`;
+    demoScene.createAgent(x, y, CX + (Math.random() - 0.5) * 200, CY + (Math.random() - 0.5) * 200, color);
+});
+
+canvas.addEventListener('contextmenu', (e: MouseEvent) => {
+    e.preventDefault();
+    const rect = canvas.getBoundingClientRect();
+    const x = (e.clientX - rect.left) * (canvas.width / rect.width);
+    const y = (e.clientY - rect.top) * (canvas.height / rect.height);
+
+    // Right click adds obstacle to AvoidanceWorldComponent
+    // ORCA uses math coords (Y up), so screen CW order = math CCW
+    // Order: top-left → top-right → bottom-right → bottom-left
+    if (worldComponent) {
+        worldComponent.addObstacle({
+            vertices: [
+                { x: x - 15, y: y - 15 },  // top-left
+                { x: x + 15, y: y - 15 },  // top-right
+                { x: x + 15, y: y + 15 },  // bottom-right
+                { x: x - 15, y: y + 15 }   // bottom-left
+            ]
+        });
+    }
+});
+
 let lastTime = performance.now();
 let animationId: number;
 
@@ -263,6 +339,10 @@ gameLoop();`;
 This is an interactive demo showcasing the ORCA (Optimal Reciprocal Collision Avoidance) algorithm, implemented with **ECS architecture**.
 
 Click **Run** to start the simulation. Use toolbar buttons to switch scenes and adjust parameters to observe different behaviors.
+
+**Interactive Controls:**
+- **Left-click** on canvas to add new agent
+- **Right-click** on canvas to place obstacle
 
 <DemoPlayground
     client:load

--- a/docs/src/content/docs/en/examples/search-visualization-demo.mdx
+++ b/docs/src/content/docs/en/examples/search-visualization-demo.mdx
@@ -1,0 +1,543 @@
+---
+title: "A* Search Visualization"
+description: "Visualize the A* algorithm search process to understand heuristic search principles"
+---
+
+import DemoPlayground from '../../../../components/DemoPlayground.vue';
+
+export const vizScenes = [
+    { id: 'simple', label: '○', name: 'Simple Path' },
+    { id: 'obstacle', label: '⬛', name: 'Obstacle' },
+    { id: 'maze', label: '⬜', name: 'Maze' },
+    { id: 'deadend', label: '✕', name: 'Dead End Test' }
+];
+
+export const vizParams = [
+    { id: 'gridSize', label: 'Grid', desc: 'Grid size', value: 25, min: 15, max: 40, step: 5 },
+    { id: 'speed', label: 'Speed', desc: 'Search speed (steps/frame)', value: 3, min: 1, max: 20, step: 1 },
+    { id: 'diagonal', label: 'Diagonal', desc: 'Diagonal movement (0=no, 1=yes)', value: 1, min: 0, max: 1, step: 1 }
+];
+
+export const vizDemoCode = `// A* Search Visualization - Understanding Heuristic Search
+// ============================================
+// Observe Open Set (frontier) and Closed Set (explored) changes
+
+const { createGridMap } = ESEngine;
+
+const WIDTH = 580, HEIGHT = 380;
+
+const params = window.__demoParams || {
+    gridSize: 25, speed: 3, diagonal: 1
+};
+
+// Local heuristic functions
+function manhattanDist(a, b) {
+    return Math.abs(a.x - b.x) + Math.abs(a.y - b.y);
+}
+
+function octileDist(a, b) {
+    const dx = Math.abs(a.x - b.x);
+    const dy = Math.abs(a.y - b.y);
+    return dx + dy + (1.414 - 2) * Math.min(dx, dy);
+}
+
+let gridMap = null;
+let gridWidth = 25, gridHeight = 16;
+let startPos = { x: 2, y: 2 };
+let endPos = { x: 0, y: 0 };
+
+// Search state
+let searchState = {
+    running: false,
+    completed: false,
+    found: false,
+    openSet: new Map(),      // key -> { x, y, g, h, f, parent }
+    closedSet: new Set(),    // key strings
+    path: [],
+    currentBest: null,
+    nodesSearched: 0,
+    startTime: 0,
+    endTime: 0
+};
+
+// ============================================
+// Visualization A* Implementation
+// ============================================
+
+function nodeKey(x, y) {
+    return x + ',' + y;
+}
+
+function initSearch() {
+    const h = params.diagonal === 1
+        ? octileDist(startPos, endPos)
+        : manhattanDist(startPos, endPos);
+
+    searchState = {
+        running: true,
+        completed: false,
+        found: false,
+        openSet: new Map(),
+        closedSet: new Set(),
+        path: [],
+        currentBest: null,
+        nodesSearched: 0,
+        startTime: performance.now(),
+        endTime: 0
+    };
+
+    searchState.openSet.set(nodeKey(startPos.x, startPos.y), {
+        x: startPos.x,
+        y: startPos.y,
+        g: 0,
+        h: h,
+        f: h,
+        parent: null
+    });
+}
+
+function stepSearch() {
+    if (!searchState.running || searchState.completed) return;
+
+    const { openSet, closedSet } = searchState;
+
+    if (openSet.size === 0) {
+        searchState.completed = true;
+        searchState.running = false;
+        searchState.found = false;
+        searchState.endTime = performance.now();
+        return;
+    }
+
+    // Find node with minimum f value
+    let bestKey = null;
+    let bestNode = null;
+    for (const [key, node] of openSet) {
+        if (!bestNode || node.f < bestNode.f || (node.f === bestNode.f && node.h < bestNode.h)) {
+            bestKey = key;
+            bestNode = node;
+        }
+    }
+
+    searchState.currentBest = bestNode;
+    searchState.nodesSearched++;
+
+    // Check if reached goal
+    if (bestNode.x === endPos.x && bestNode.y === endPos.y) {
+        searchState.completed = true;
+        searchState.running = false;
+        searchState.found = true;
+        searchState.endTime = performance.now();
+
+        // Reconstruct path
+        const path = [];
+        let current = bestNode;
+        while (current) {
+            path.unshift({ x: current.x, y: current.y });
+            current = current.parent;
+        }
+        searchState.path = path;
+        return;
+    }
+
+    // Move from open to closed set
+    openSet.delete(bestKey);
+    closedSet.add(bestKey);
+
+    // Expand neighbors
+    const neighbors = getNeighbors(bestNode.x, bestNode.y);
+    for (const neighbor of neighbors) {
+        const key = nodeKey(neighbor.x, neighbor.y);
+
+        if (closedSet.has(key)) continue;
+        if (!gridMap.isWalkable(neighbor.x, neighbor.y)) continue;
+
+        const tentativeG = bestNode.g + neighbor.cost;
+
+        const existing = openSet.get(key);
+        if (existing && tentativeG >= existing.g) continue;
+
+        const h = params.diagonal === 1
+            ? octileDist(neighbor, endPos)
+            : manhattanDist(neighbor, endPos);
+
+        const newNode = {
+            x: neighbor.x,
+            y: neighbor.y,
+            g: tentativeG,
+            h: h,
+            f: tentativeG + h,
+            parent: bestNode
+        };
+
+        openSet.set(key, newNode);
+    }
+}
+
+function getNeighbors(x, y) {
+    const neighbors = [];
+    const dirs4 = [[0, -1], [1, 0], [0, 1], [-1, 0]];
+    const dirs8 = [[0, -1], [1, -1], [1, 0], [1, 1], [0, 1], [-1, 1], [-1, 0], [-1, -1]];
+    const dirs = params.diagonal === 1 ? dirs8 : dirs4;
+
+    for (let i = 0; i < dirs.length; i++) {
+        const [dx, dy] = dirs[i];
+        const nx = x + dx, ny = y + dy;
+        if (nx >= 0 && nx < gridWidth && ny >= 0 && ny < gridHeight) {
+            const cost = (dx !== 0 && dy !== 0) ? 1.414 : 1;
+            neighbors.push({ x: nx, y: ny, cost });
+        }
+    }
+    return neighbors;
+}
+
+// ============================================
+// Rendering
+// ============================================
+
+function render(ctx) {
+    if (!gridMap) return;
+
+    const cellW = WIDTH / gridWidth;
+    const cellH = HEIGHT / gridHeight;
+
+    // Clear screen
+    ctx.fillStyle = '#16213e';
+    ctx.fillRect(0, 0, WIDTH, HEIGHT);
+
+    // Draw obstacles (first, as background)
+    ctx.fillStyle = '#2d4263';
+    for (let y = 0; y < gridHeight; y++) {
+        for (let x = 0; x < gridWidth; x++) {
+            if (!gridMap.isWalkable(x, y)) {
+                ctx.fillRect(x * cellW, y * cellH, cellW - 1, cellH - 1);
+            }
+        }
+    }
+
+    // Draw Closed Set (explored)
+    ctx.fillStyle = 'rgba(100, 100, 150, 0.6)';
+    for (const key of searchState.closedSet) {
+        const [x, y] = key.split(',').map(Number);
+        ctx.fillRect(x * cellW + 1, y * cellH + 1, cellW - 2, cellH - 2);
+    }
+
+    // Draw Open Set (frontier)
+    for (const [key, node] of searchState.openSet) {
+        // Color intensity based on f value
+        const intensity = Math.max(0.3, 1 - node.f / 100);
+        ctx.fillStyle = \`rgba(0, 200, 255, \${intensity * 0.7})\`;
+        ctx.fillRect(node.x * cellW + 1, node.y * cellH + 1, cellW - 2, cellH - 2);
+    }
+
+    // Draw final path
+    if (searchState.path.length > 0) {
+        ctx.strokeStyle = '#4ecdc4';
+        ctx.lineWidth = 3;
+        ctx.beginPath();
+        ctx.moveTo(searchState.path[0].x * cellW + cellW/2, searchState.path[0].y * cellH + cellH/2);
+        for (let i = 1; i < searchState.path.length; i++) {
+            ctx.lineTo(searchState.path[i].x * cellW + cellW/2, searchState.path[i].y * cellH + cellH/2);
+        }
+        ctx.stroke();
+    }
+
+    // Current best path to start
+    if (searchState.currentBest && !searchState.completed) {
+        ctx.strokeStyle = 'rgba(255, 230, 109, 0.6)';
+        ctx.lineWidth = 2;
+        ctx.beginPath();
+        let node = searchState.currentBest;
+        ctx.moveTo(node.x * cellW + cellW/2, node.y * cellH + cellH/2);
+        while (node.parent) {
+            node = node.parent;
+            ctx.lineTo(node.x * cellW + cellW/2, node.y * cellH + cellH/2);
+        }
+        ctx.stroke();
+    }
+
+    // Draw grid lines
+    ctx.strokeStyle = 'rgba(255,255,255,0.15)';
+    ctx.lineWidth = 1;
+    for (let x = 0; x <= gridWidth; x++) {
+        ctx.beginPath();
+        ctx.moveTo(x * cellW, 0);
+        ctx.lineTo(x * cellW, HEIGHT);
+        ctx.stroke();
+    }
+    for (let y = 0; y <= gridHeight; y++) {
+        ctx.beginPath();
+        ctx.moveTo(0, y * cellH);
+        ctx.lineTo(WIDTH, y * cellH);
+        ctx.stroke();
+    }
+
+    // Draw start
+    ctx.fillStyle = '#00d4ff';
+    ctx.beginPath();
+    ctx.arc(startPos.x * cellW + cellW/2, startPos.y * cellH + cellH/2, Math.min(cellW, cellH) * 0.35, 0, Math.PI * 2);
+    ctx.fill();
+
+    // Draw end
+    ctx.fillStyle = '#ff6b6b';
+    ctx.beginPath();
+    ctx.arc(endPos.x * cellW + cellW/2, endPos.y * cellH + cellH/2, Math.min(cellW, cellH) * 0.35, 0, Math.PI * 2);
+    ctx.fill();
+
+    // HUD
+    const panelX = 5, panelY = 5;
+    ctx.fillStyle = 'rgba(0,0,0,0.8)';
+    ctx.fillRect(panelX, panelY, 175, 100);
+
+    ctx.font = 'bold 11px monospace';
+    ctx.fillStyle = '#fff';
+    ctx.fillText('A* Search Visualization', panelX + 5, panelY + 15);
+
+    ctx.font = '10px monospace';
+    ctx.fillStyle = '#00d4ff';
+    ctx.fillText(\`Open Set:   \${searchState.openSet.size}\`, panelX + 5, panelY + 32);
+    ctx.fillStyle = 'rgba(150, 150, 200, 1)';
+    ctx.fillText(\`Closed Set: \${searchState.closedSet.size}\`, panelX + 5, panelY + 45);
+    ctx.fillStyle = '#ffe66d';
+    ctx.fillText(\`Nodes:      \${searchState.nodesSearched}\`, panelX + 5, panelY + 58);
+
+    if (searchState.completed) {
+        const time = (searchState.endTime - searchState.startTime).toFixed(2);
+        ctx.fillStyle = searchState.found ? '#4ecdc4' : '#ff6b6b';
+        ctx.fillText(searchState.found ? \`Path found! \${searchState.path.length} nodes\` : 'No path found!', panelX + 5, panelY + 73);
+        ctx.fillStyle = '#888';
+        ctx.fillText(\`Time: \${time}ms\`, panelX + 5, panelY + 86);
+    } else if (searchState.running) {
+        ctx.fillStyle = '#4ecdc4';
+        ctx.fillText('Searching...', panelX + 5, panelY + 73);
+    } else {
+        ctx.fillStyle = '#888';
+        ctx.fillText('Click to set start/end', panelX + 5, panelY + 73);
+    }
+
+    // Legend
+    const legendX = WIDTH - 120, legendY = 5;
+    ctx.fillStyle = 'rgba(0,0,0,0.8)';
+    ctx.fillRect(legendX, legendY, 115, 70);
+    ctx.font = '9px monospace';
+
+    ctx.fillStyle = 'rgba(0, 200, 255, 0.6)';
+    ctx.fillRect(legendX + 5, legendY + 8, 12, 12);
+    ctx.fillStyle = '#fff';
+    ctx.fillText('Open (frontier)', legendX + 22, legendY + 18);
+
+    ctx.fillStyle = 'rgba(100, 100, 150, 0.5)';
+    ctx.fillRect(legendX + 5, legendY + 25, 12, 12);
+    ctx.fillStyle = '#fff';
+    ctx.fillText('Closed (explored)', legendX + 22, legendY + 35);
+
+    ctx.fillStyle = '#ffe66d';
+    ctx.fillRect(legendX + 5, legendY + 42, 12, 12);
+    ctx.fillStyle = '#fff';
+    ctx.fillText('Current path', legendX + 22, legendY + 52);
+
+    ctx.fillStyle = '#4ecdc4';
+    ctx.fillRect(legendX + 5, legendY + 59, 12, 12);
+    ctx.fillStyle = '#fff';
+    ctx.fillText('Final path', legendX + 22, legendY + 69);
+}
+
+// ============================================
+// Map Generation
+// ============================================
+
+function generateMap(type) {
+    gridWidth = params.gridSize;
+    gridHeight = Math.floor(gridWidth * HEIGHT / WIDTH);
+
+    gridMap = createGridMap(gridWidth, gridHeight);
+
+    // Reset search state
+    searchState = {
+        running: false,
+        completed: false,
+        found: false,
+        openSet: new Map(),
+        closedSet: new Set(),
+        path: [],
+        currentBest: null,
+        nodesSearched: 0,
+        startTime: 0,
+        endTime: 0
+    };
+
+    const w = gridWidth, h = gridHeight;
+
+    const generators = {
+        simple: () => {
+            // Empty map, simple path
+            startPos = { x: 2, y: Math.floor(h / 2) };
+            endPos = { x: w - 3, y: Math.floor(h / 2) };
+        },
+        obstacle: () => {
+            // Obstacle in the middle
+            const midX = Math.floor(w / 2);
+            for (let y = 3; y < h - 3; y++) {
+                gridMap.setWalkable(midX, y, false);
+            }
+            startPos = { x: 3, y: Math.floor(h / 2) };
+            endPos = { x: w - 4, y: Math.floor(h / 2) };
+        },
+        maze: () => {
+            // Simple maze
+            for (let y = 0; y < h; y++) {
+                for (let x = 0; x < w; x++) {
+                    gridMap.setWalkable(x, y, false);
+                }
+            }
+            const carve = (x, y) => {
+                gridMap.setWalkable(x, y, true);
+                const dirs = [[0,-2],[0,2],[-2,0],[2,0]].sort(() => Math.random() - 0.5);
+                for (const [dx, dy] of dirs) {
+                    const nx = x + dx, ny = y + dy;
+                    if (nx > 0 && nx < w-1 && ny > 0 && ny < h-1 && !gridMap.isWalkable(nx, ny)) {
+                        gridMap.setWalkable(x + dx/2, y + dy/2, true);
+                        carve(nx, ny);
+                    }
+                }
+            };
+            carve(1, 1);
+            startPos = { x: 1, y: 1 };
+            endPos = findWalkable(w - 2, h - 2);
+        },
+        deadend: () => {
+            // Dead end test (goal is surrounded)
+            const cx = Math.floor(w / 2);
+            const cy = Math.floor(h / 2);
+            // Walls
+            for (let x = cx - 3; x <= cx + 3; x++) {
+                gridMap.setWalkable(x, cy - 3, false);
+                gridMap.setWalkable(x, cy + 3, false);
+            }
+            for (let y = cy - 3; y <= cy + 3; y++) {
+                gridMap.setWalkable(cx - 3, y, false);
+                gridMap.setWalkable(cx + 3, y, false);
+            }
+            startPos = { x: 2, y: 2 };
+            endPos = { x: cx, y: cy };
+        }
+    };
+
+    generators[type]?.();
+}
+
+function findWalkable(px, py) {
+    if (gridMap.isWalkable(px, py)) return { x: px, y: py };
+    for (let r = 1; r < 20; r++) {
+        for (let dx = -r; dx <= r; dx++) {
+            for (let dy = -r; dy <= r; dy++) {
+                const x = px + dx, y = py + dy;
+                if (x >= 0 && x < gridWidth && y >= 0 && y < gridHeight) {
+                    if (gridMap.isWalkable(x, y)) return { x, y };
+                }
+            }
+        }
+    }
+    return { x: 1, y: 1 };
+}
+
+// ============================================
+// Initialize
+// ============================================
+
+generateMap('simple');
+initSearch();  // Auto-start search
+
+// Click to set start/end and begin search
+let clickMode = 'start';
+canvas.addEventListener('click', (e) => {
+    const rect = canvas.getBoundingClientRect();
+    const mx = (e.clientX - rect.left) * (canvas.width / rect.width);
+    const my = (e.clientY - rect.top) * (canvas.height / rect.height);
+    const cellW = WIDTH / gridWidth;
+    const cellH = HEIGHT / gridHeight;
+    const gx = Math.floor(mx / cellW);
+    const gy = Math.floor(my / cellH);
+
+    if (gx >= 0 && gx < gridWidth && gy >= 0 && gy < gridHeight && gridMap.isWalkable(gx, gy)) {
+        if (clickMode === 'start') {
+            startPos = { x: gx, y: gy };
+            clickMode = 'end';
+        } else {
+            endPos = { x: gx, y: gy };
+            clickMode = 'start';
+            // Start search
+            initSearch();
+        }
+    }
+});
+
+// Scene switching
+window.__demoScene = {
+    loadScenario: (type) => {
+        generateMap(type);
+        initSearch();
+    }
+};
+
+// Game loop
+function gameLoop() {
+    // Execute multiple search steps per frame
+    if (searchState.running) {
+        for (let i = 0; i < params.speed; i++) {
+            stepSearch();
+        }
+    }
+
+    render(ctx);
+    requestAnimationFrame(gameLoop);
+}
+
+gameLoop();`;
+
+This is an **A* Search Visualization Demo** to help understand how heuristic search algorithms work.
+
+Click **Run** to start, then click on the map to set start and end points.
+
+**Color Legend:**
+- 🟦 **Blue** - Open Set (frontier nodes to be explored)
+- 🟫 **Gray-purple** - Closed Set (already explored nodes)
+- 🟨 **Yellow line** - Current best path
+- 🟩 **Cyan line** - Final path
+
+<DemoPlayground
+    client:load
+    title="A* Search Visualization"
+    code={vizDemoCode}
+    canvasWidth={580}
+    canvasHeight={380}
+    scenes={vizScenes}
+    params={vizParams}
+/>
+
+<script is:inline src="/esengine/js/esengine.iife.js"></script>
+
+## A* Algorithm Principles
+
+A* algorithm maintains two sets to search for the shortest path:
+
+| Set | Purpose |
+|-----|---------|
+| **Open Set** | Discovered but unexplored nodes (search frontier) |
+| **Closed Set** | Fully explored nodes |
+
+Each iteration expands the node with minimum **f(n) = g(n) + h(n)** from the Open Set:
+- **g(n)** - Actual cost from start to current node
+- **h(n)** - Heuristic estimate from current node to goal
+
+## Scene Descriptions
+
+- **Simple Path** - No obstacles, observe how the algorithm "heads straight" to the goal
+- **Obstacle** - See how the algorithm adjusts direction when encountering obstacles
+- **Maze** - Search behavior in complex environments
+- **Dead End Test** - Goal is surrounded, observe the algorithm exploring the entire reachable area
+
+## Related Documentation
+
+- [Algorithm Comparison Demo](/esengine/en/examples/algorithm-comparison-demo) - Compare different algorithms
+- [Pathfinding System API](/esengine/en/modules/pathfinding) - Complete documentation

--- a/docs/src/content/docs/en/modules/pathfinding/index.md
+++ b/docs/src/content/docs/en/modules/pathfinding/index.md
@@ -323,6 +323,14 @@ for (let y = 30; y < 35; y++) {
 | Dynamic Updates | Easy | Requires rebuild |
 | Setup Complexity | Simple | More complex |
 
+## Interactive Demos
+
+Experience the pathfinding system with interactive demos:
+
+- [A* Pathfinding Demo](/esengine/en/examples/astar-pathfinding-demo) - Grid pathfinding visualization
+- [Multi-Agent Pathfinding Demo](/esengine/en/examples/multi-agent-pathfinding-demo) - A* + ORCA avoidance combined
+- [ORCA Local Avoidance Demo](/esengine/en/examples/orca-avoidance-demo) - Multi-agent collision avoidance
+
 ## Documentation
 
 - [Grid Map API](./grid-map) - Grid operations and A* pathfinder

--- a/docs/src/content/docs/examples/algorithm-comparison-demo.mdx
+++ b/docs/src/content/docs/examples/algorithm-comparison-demo.mdx
@@ -1,0 +1,405 @@
+---
+title: "寻路算法对比"
+description: "对比 A*、双向 A*、JPS 算法的性能和搜索过程"
+---
+
+import DemoPlayground from '../../../components/DemoPlayground.vue';
+
+export const algoScenes = [
+    { id: 'open', label: '○', name: '开阔地形' },
+    { id: 'maze', label: '⬛', name: '迷宫' },
+    { id: 'rooms', label: '⬜', name: '房间' },
+    { id: 'dense', label: '▓', name: '密集障碍' }
+];
+
+export const algoParams = [
+    { id: 'gridSize', label: 'Grid', desc: '网格大小', value: 60, min: 30, max: 100, step: 10 },
+    { id: 'obstacleRate', label: 'Obstacles', desc: '障碍物密度（%）', value: 30, min: 10, max: 50, step: 5 }
+];
+
+export const algoDemoCode = `// 寻路算法对比 - A* vs 双向A* vs JPS
+// ============================================
+// 对比不同算法的搜索效率和路径质量
+
+const {
+    Core, Scene, Component, EntitySystem, Matcher, Time,
+    ECSComponent, ECSSystem,
+    GridMap, createGridMap,
+    AStarPathfinder, GridPathfinder, JPSPathfinder,
+    octileDistance
+} = ESEngine;
+
+const WIDTH = 580, HEIGHT = 380;
+
+const params = window.__demoParams || {
+    gridSize: 60, obstacleRate: 30
+};
+
+// 算法结果存储
+let results = {
+    astar: { time: 0, nodes: 0, pathLen: 0, path: [] },
+    bidir: { time: 0, nodes: 0, pathLen: 0, path: [] },
+    jps: { time: 0, nodes: 0, pathLen: 0, path: [] }
+};
+
+let gridMap = null;
+let startPos = { x: 2, y: 2 };
+let endPos = { x: 0, y: 0 };
+let selectedAlgo = 'all'; // 'all', 'astar', 'bidir', 'jps'
+
+// ============================================
+// 渲染
+// ============================================
+
+function render(ctx) {
+    if (!gridMap) return;
+
+    const cellW = WIDTH / gridMap.width;
+    const cellH = HEIGHT / gridMap.height;
+
+    // 清屏
+    ctx.fillStyle = '#16213e';
+    ctx.fillRect(0, 0, WIDTH, HEIGHT);
+
+    // 绘制障碍物
+    ctx.fillStyle = '#2d4263';
+    for (let y = 0; y < gridMap.height; y++) {
+        for (let x = 0; x < gridMap.width; x++) {
+            if (!gridMap.isWalkable(x, y)) {
+                ctx.fillRect(x * cellW, y * cellH, cellW - 1, cellH - 1);
+            }
+        }
+    }
+
+    // 绘制网格线
+    ctx.strokeStyle = 'rgba(255,255,255,0.03)';
+    ctx.lineWidth = 1;
+    for (let x = 0; x <= gridMap.width; x++) {
+        ctx.beginPath();
+        ctx.moveTo(x * cellW, 0);
+        ctx.lineTo(x * cellW, HEIGHT);
+        ctx.stroke();
+    }
+    for (let y = 0; y <= gridMap.height; y++) {
+        ctx.beginPath();
+        ctx.moveTo(0, y * cellH);
+        ctx.lineTo(WIDTH, y * cellH);
+        ctx.stroke();
+    }
+
+    // 绘制路径
+    const colors = {
+        astar: { stroke: '#ff6b6b', fill: 'rgba(255,107,107,0.3)', name: 'A*' },
+        bidir: { stroke: '#4ecdc4', fill: 'rgba(78,205,196,0.3)', name: 'Bidirectional' },
+        jps: { stroke: '#ffe66d', fill: 'rgba(255,230,109,0.3)', name: 'JPS' }
+    };
+
+    const drawPath = (path, color, offset) => {
+        if (path.length < 2) return;
+        ctx.strokeStyle = color.stroke;
+        ctx.lineWidth = 2;
+        ctx.beginPath();
+        ctx.moveTo(path[0].x * cellW + cellW/2 + offset, path[0].y * cellH + cellH/2);
+        for (let i = 1; i < path.length; i++) {
+            ctx.lineTo(path[i].x * cellW + cellW/2 + offset, path[i].y * cellH + cellH/2);
+        }
+        ctx.stroke();
+    };
+
+    // 根据选择显示路径
+    if (selectedAlgo === 'all' || selectedAlgo === 'astar') {
+        drawPath(results.astar.path, colors.astar, -2);
+    }
+    if (selectedAlgo === 'all' || selectedAlgo === 'bidir') {
+        drawPath(results.bidir.path, colors.bidir, 0);
+    }
+    if (selectedAlgo === 'all' || selectedAlgo === 'jps') {
+        drawPath(results.jps.path, colors.jps, 2);
+    }
+
+    // 绘制起点终点
+    ctx.fillStyle = '#00d4ff';
+    ctx.beginPath();
+    ctx.arc(startPos.x * cellW + cellW/2, startPos.y * cellH + cellH/2, 6, 0, Math.PI * 2);
+    ctx.fill();
+
+    ctx.fillStyle = '#ff6b6b';
+    ctx.beginPath();
+    ctx.arc(endPos.x * cellW + cellW/2, endPos.y * cellH + cellH/2, 6, 0, Math.PI * 2);
+    ctx.fill();
+
+    // HUD - 算法对比面板
+    const panelX = 5, panelY = 5;
+    const panelW = 200, panelH = 95;
+    ctx.fillStyle = 'rgba(0,0,0,0.75)';
+    ctx.fillRect(panelX, panelY, panelW, panelH);
+
+    ctx.font = 'bold 11px monospace';
+    ctx.fillStyle = '#fff';
+    ctx.fillText('Algorithm Comparison', panelX + 5, panelY + 15);
+
+    ctx.font = '10px monospace';
+    const algos = ['astar', 'bidir', 'jps'];
+    const labels = ['A*', 'Bi-A*', 'JPS'];
+
+    // 表头
+    ctx.fillStyle = '#888';
+    ctx.fillText('Algo    Time    Nodes   Path', panelX + 5, panelY + 30);
+
+    algos.forEach((algo, i) => {
+        const r = results[algo];
+        const y = panelY + 45 + i * 15;
+        ctx.fillStyle = colors[algo].stroke;
+        ctx.fillText(
+            \`\${labels[i].padEnd(6)} \${r.time.toFixed(2).padStart(6)}ms \${String(r.nodes).padStart(5)} \${String(r.pathLen).padStart(5)}\`,
+            panelX + 5, y
+        );
+    });
+
+    // 提示
+    ctx.fillStyle = '#666';
+    ctx.font = '9px monospace';
+    ctx.fillText('Click: set start/end', panelX + 5, panelY + 90);
+
+    // 图例
+    const legendX = WIDTH - 95, legendY = 5;
+    ctx.fillStyle = 'rgba(0,0,0,0.75)';
+    ctx.fillRect(legendX, legendY, 90, 55);
+    ctx.font = '10px monospace';
+    algos.forEach((algo, i) => {
+        ctx.fillStyle = colors[algo].stroke;
+        ctx.fillRect(legendX + 5, legendY + 8 + i * 15, 10, 10);
+        ctx.fillText(labels[i], legendX + 20, legendY + 17 + i * 15);
+    });
+}
+
+// ============================================
+// 寻路执行
+// ============================================
+
+function runPathfinding() {
+    if (!gridMap) return;
+
+    const options = {
+        allowDiagonal: true,
+        heuristic: octileDistance
+    };
+
+    // A* 标准
+    const astar = new AStarPathfinder(gridMap);
+    let t0 = performance.now();
+    let result = astar.findPath(startPos.x, startPos.y, endPos.x, endPos.y, options);
+    results.astar = {
+        time: performance.now() - t0,
+        nodes: result.nodesSearched,
+        pathLen: result.path.length,
+        path: result.path
+    };
+
+    // 双向 A*
+    const bidir = new GridPathfinder(gridMap, { mode: 'bidirectional' });
+    t0 = performance.now();
+    result = bidir.findPath(startPos.x, startPos.y, endPos.x, endPos.y, options);
+    results.bidir = {
+        time: performance.now() - t0,
+        nodes: result.nodesSearched,
+        pathLen: result.path.length,
+        path: result.path
+    };
+
+    // JPS
+    const jps = new JPSPathfinder(gridMap);
+    t0 = performance.now();
+    result = jps.findPath(startPos.x, startPos.y, endPos.x, endPos.y, { allowDiagonal: true });
+    results.jps = {
+        time: performance.now() - t0,
+        nodes: result.nodesSearched,
+        pathLen: result.path.length,
+        path: result.path
+    };
+}
+
+// ============================================
+// 地图生成
+// ============================================
+
+function generateMap(type) {
+    const w = params.gridSize;
+    const h = Math.floor(w * HEIGHT / WIDTH);
+
+    gridMap = createGridMap(w, h);
+
+    const generators = {
+        open: () => {
+            // 少量随机障碍
+            const rate = 0.1;
+            for (let y = 0; y < h; y++) {
+                for (let x = 0; x < w; x++) {
+                    if (Math.random() < rate) gridMap.setWalkable(x, y, false);
+                }
+            }
+        },
+        maze: () => {
+            // 迷宫
+            for (let y = 0; y < h; y++) {
+                for (let x = 0; x < w; x++) {
+                    gridMap.setWalkable(x, y, false);
+                }
+            }
+            const carve = (x, y) => {
+                gridMap.setWalkable(x, y, true);
+                const dirs = [[0,-2],[0,2],[-2,0],[2,0]].sort(() => Math.random() - 0.5);
+                for (const [dx, dy] of dirs) {
+                    const nx = x + dx, ny = y + dy;
+                    if (nx > 0 && nx < w-1 && ny > 0 && ny < h-1 && !gridMap.isWalkable(nx, ny)) {
+                        gridMap.setWalkable(x + dx/2, y + dy/2, true);
+                        carve(nx, ny);
+                    }
+                }
+            };
+            carve(1, 1);
+        },
+        rooms: () => {
+            // 房间布局
+            const roomW = Math.floor(w / 4);
+            const roomH = Math.floor(h / 3);
+            for (let ry = 0; ry < 3; ry++) {
+                for (let rx = 0; rx < 4; rx++) {
+                    const bx = rx * roomW, by = ry * roomH;
+                    for (let x = bx; x < bx + roomW && x < w; x++) {
+                        if (by < h) gridMap.setWalkable(x, by, false);
+                        if (by + roomH - 1 < h) gridMap.setWalkable(x, by + roomH - 1, false);
+                    }
+                    for (let y = by; y < by + roomH && y < h; y++) {
+                        if (bx < w) gridMap.setWalkable(bx, y, false);
+                        if (bx + roomW - 1 < w) gridMap.setWalkable(bx + roomW - 1, y, false);
+                    }
+                    // 门
+                    const doorX = bx + Math.floor(roomW / 2);
+                    const doorY = by + Math.floor(roomH / 2);
+                    if (doorX < w && by < h) gridMap.setWalkable(doorX, by, true);
+                    if (doorX < w && by + roomH - 1 < h) gridMap.setWalkable(doorX, by + roomH - 1, true);
+                    if (bx < w && doorY < h) gridMap.setWalkable(bx, doorY, true);
+                    if (bx + roomW - 1 < w && doorY < h) gridMap.setWalkable(bx + roomW - 1, doorY, true);
+                }
+            }
+        },
+        dense: () => {
+            // 密集随机障碍
+            const rate = params.obstacleRate / 100;
+            for (let y = 0; y < h; y++) {
+                for (let x = 0; x < w; x++) {
+                    if (Math.random() < rate) gridMap.setWalkable(x, y, false);
+                }
+            }
+        }
+    };
+
+    generators[type]?.();
+
+    // 设置起点终点
+    startPos = findWalkable(2, 2);
+    endPos = findWalkable(w - 3, h - 3);
+
+    runPathfinding();
+}
+
+function findWalkable(px, py) {
+    if (gridMap.isWalkable(px, py)) return { x: px, y: py };
+    for (let r = 1; r < 20; r++) {
+        for (let dx = -r; dx <= r; dx++) {
+            for (let dy = -r; dy <= r; dy++) {
+                const x = px + dx, y = py + dy;
+                if (x >= 0 && x < gridMap.width && y >= 0 && y < gridMap.height) {
+                    if (gridMap.isWalkable(x, y)) return { x, y };
+                }
+            }
+        }
+    }
+    return { x: 1, y: 1 };
+}
+
+// ============================================
+// 初始化
+// ============================================
+
+generateMap('open');
+
+// 鼠标交互
+let clickMode = 'start'; // 'start' or 'end'
+canvas.addEventListener('click', (e) => {
+    const rect = canvas.getBoundingClientRect();
+    const mx = (e.clientX - rect.left) * (canvas.width / rect.width);
+    const my = (e.clientY - rect.top) * (canvas.height / rect.height);
+    const cellW = WIDTH / gridMap.width;
+    const cellH = HEIGHT / gridMap.height;
+    const gx = Math.floor(mx / cellW);
+    const gy = Math.floor(my / cellH);
+
+    if (gridMap.isWalkable(gx, gy)) {
+        if (clickMode === 'start') {
+            startPos = { x: gx, y: gy };
+            clickMode = 'end';
+        } else {
+            endPos = { x: gx, y: gy };
+            clickMode = 'start';
+        }
+        runPathfinding();
+    }
+});
+
+// 场景切换支持
+window.__demoScene = {
+    loadScenario: (type) => {
+        generateMap(type);
+    }
+};
+
+// 游戏循环
+function gameLoop() {
+    render(ctx);
+    requestAnimationFrame(gameLoop);
+}
+
+gameLoop();`;
+
+这是一个**寻路算法对比演示**，展示 A*、双向 A* 和 JPS 三种算法的性能差异。
+
+点击 **Run** 开始运行。点击地图可以设置起点/终点，观察不同算法的搜索效率。
+
+**算法特点：**
+- **A*** - 经典启发式搜索，适合中小型地图
+- **双向 A*** - 从起点和终点同时搜索，大地图更高效
+- **JPS (跳点搜索)** - 在开阔地形优势明显，可跳过大量节点
+
+<DemoPlayground
+    client:load
+    title="寻路算法对比 - A* vs 双向A* vs JPS"
+    code={algoDemoCode}
+    canvasWidth={580}
+    canvasHeight={380}
+    scenes={algoScenes}
+    params={algoParams}
+/>
+
+<script is:inline src="/esengine/js/esengine.iife.js"></script>
+
+## 性能指标说明
+
+| 指标 | 说明 |
+|------|------|
+| **Time** | 寻路耗时（毫秒） |
+| **Nodes** | 搜索的节点数量（越少越高效） |
+| **Path** | 最终路径长度（节点数） |
+
+## 场景说明
+
+- **开阔地形** - JPS 优势明显，可跳过大量空白区域
+- **迷宫** - 通道狭窄，算法差异较小
+- **房间** - 模拟室内环境，需要穿过门廊
+- **密集障碍** - 随机分布，测试一般情况
+
+## 相关文档
+
+- [A* 寻路演示](/esengine/examples/astar-pathfinding-demo) - 基础 A* 演示
+- [寻路系统 API](/esengine/modules/pathfinding) - 完整 API 文档

--- a/docs/src/content/docs/examples/astar-pathfinding-demo.mdx
+++ b/docs/src/content/docs/examples/astar-pathfinding-demo.mdx
@@ -1,0 +1,488 @@
+---
+title: "A* 寻路演示"
+description: "使用 ECS 架构实现的 A* 网格寻路交互式演示"
+---
+
+import DemoPlayground from '../../../components/DemoPlayground.vue';
+
+export const astarScenes = [
+    { id: 'maze', label: '⬛', name: '迷宫' },
+    { id: 'random', label: '✦', name: '随机障碍' },
+    { id: 'rooms', label: '⬜', name: '房间' },
+    { id: 'spiral', label: '◎', name: '螺旋' }
+];
+
+export const astarParams = [
+    { id: 'gridSize', label: 'Grid', desc: '网格大小（越大越精细）', value: 40, min: 20, max: 80, step: 10 },
+    { id: 'obstacleRate', label: 'Obstacles', desc: '障碍物密度（%）', value: 25, min: 10, max: 50, step: 5 },
+    { id: 'diagonal', label: 'Diagonal', desc: '是否允许对角移动（0=否，1=是）', value: 1, min: 0, max: 1, step: 1 },
+    { id: 'speed', label: 'Speed', desc: '代理移动速度（网格/秒）', value: 5, min: 1, max: 15, step: 1 }
+];
+
+export const astarDemoCode = `// A* 寻路 - ECS 架构演示
+// ============================================
+// 点击地图设置起点和终点，观察 A* 寻路过程
+
+const {
+    Core, Scene, Component, EntitySystem, Matcher, Time,
+    ECSComponent, ECSSystem,
+    PathfindingAgentComponent, PathfindingMapComponent, PathfindingSystem
+} = ESEngine;
+
+const WIDTH = 580, HEIGHT = 380;
+
+const params = window.__demoParams || {
+    gridSize: 40, obstacleRate: 25, diagonal: 1, speed: 5
+};
+
+// ============================================
+// 组件定义
+// ============================================
+
+@ECSComponent('Visual')
+class VisualComponent extends Component {
+    color = '#00d4ff';
+    showPath = true;
+}
+
+// ============================================
+// 渲染系统
+// ============================================
+
+@ECSSystem('Render', { updateOrder: 100 })
+class RenderSystem extends EntitySystem {
+    ctx: CanvasRenderingContext2D;
+    mapComp: PathfindingMapComponent | null = null;
+    fps = 0; frameCount = 0; lastFpsTime = 0;
+
+    constructor(context: CanvasRenderingContext2D) {
+        super(Matcher.all(PathfindingAgentComponent, VisualComponent));
+        this.ctx = context;
+    }
+
+    process(entities) {
+        const ctx = this.ctx;
+
+        // 清屏
+        ctx.fillStyle = '#16213e';
+        ctx.fillRect(0, 0, WIDTH, HEIGHT);
+
+        // 查找地图组件
+        if (!this.mapComp) {
+            const mapEntities = this.scene.entities.findEntitiesWithComponent(PathfindingMapComponent);
+            if (mapEntities.length > 0) {
+                this.mapComp = mapEntities[0].getComponent(PathfindingMapComponent);
+            }
+        }
+
+        // 绘制网格
+        if (this.mapComp?.map) {
+            const map = this.mapComp.map;
+            const cellW = WIDTH / map.width;
+            const cellH = HEIGHT / map.height;
+
+            // 绘制障碍物
+            ctx.fillStyle = '#2d4263';
+            for (let y = 0; y < map.height; y++) {
+                for (let x = 0; x < map.width; x++) {
+                    if (!map.isWalkable(x, y)) {
+                        ctx.fillRect(x * cellW, y * cellH, cellW - 1, cellH - 1);
+                    }
+                }
+            }
+
+            // 绘制网格线
+            ctx.strokeStyle = 'rgba(255,255,255,0.05)';
+            ctx.lineWidth = 1;
+            for (let x = 0; x <= map.width; x++) {
+                ctx.beginPath();
+                ctx.moveTo(x * cellW, 0);
+                ctx.lineTo(x * cellW, HEIGHT);
+                ctx.stroke();
+            }
+            for (let y = 0; y <= map.height; y++) {
+                ctx.beginPath();
+                ctx.moveTo(0, y * cellH);
+                ctx.lineTo(WIDTH, y * cellH);
+                ctx.stroke();
+            }
+        }
+
+        // FPS 计算
+        this.frameCount++;
+        const now = performance.now();
+        if (now - this.lastFpsTime >= 1000) {
+            this.fps = this.frameCount;
+            this.frameCount = 0;
+            this.lastFpsTime = now;
+        }
+
+        // 绘制代理和路径
+        for (const entity of entities) {
+            const agent = entity.getComponent(PathfindingAgentComponent);
+            const visual = entity.getComponent(VisualComponent);
+
+            if (!this.mapComp?.map) continue;
+            const cellW = WIDTH / this.mapComp.map.width;
+            const cellH = HEIGHT / this.mapComp.map.height;
+
+            // 绘制路径
+            if (visual.showPath && agent.path.length > 0) {
+                ctx.strokeStyle = 'rgba(0, 212, 255, 0.4)';
+                ctx.lineWidth = 3;
+                ctx.beginPath();
+                ctx.moveTo(agent.x * cellW + cellW/2, agent.y * cellH + cellH/2);
+                for (const p of agent.path) {
+                    ctx.lineTo(p.x * cellW + cellW/2, p.y * cellH + cellH/2);
+                }
+                ctx.stroke();
+
+                // 绘制路径点
+                ctx.fillStyle = 'rgba(0, 212, 255, 0.6)';
+                for (let i = agent.pathIndex; i < agent.path.length; i++) {
+                    const p = agent.path[i];
+                    ctx.beginPath();
+                    ctx.arc(p.x * cellW + cellW/2, p.y * cellH + cellH/2, 3, 0, Math.PI * 2);
+                    ctx.fill();
+                }
+            }
+
+            // 绘制目标点
+            ctx.fillStyle = '#ff6b6b';
+            ctx.beginPath();
+            ctx.arc(agent.targetX * cellW + cellW/2, agent.targetY * cellH + cellH/2, 6, 0, Math.PI * 2);
+            ctx.fill();
+
+            // 绘制代理
+            const x = agent.x * cellW + cellW/2;
+            const y = agent.y * cellH + cellH/2;
+
+            // 光晕
+            const gradient = ctx.createRadialGradient(x, y, 0, x, y, 12);
+            gradient.addColorStop(0, visual.color);
+            gradient.addColorStop(1, 'transparent');
+            ctx.beginPath();
+            ctx.arc(x, y, 12, 0, Math.PI * 2);
+            ctx.fillStyle = gradient;
+            ctx.fill();
+
+            // 代理圆
+            ctx.beginPath();
+            ctx.arc(x, y, 6, 0, Math.PI * 2);
+            ctx.fillStyle = visual.color;
+            ctx.fill();
+        }
+
+        // HUD
+        ctx.fillStyle = 'rgba(0,0,0,0.6)';
+        ctx.fillRect(5, 5, 140, 50);
+        ctx.fillStyle = '#00d4ff';
+        ctx.font = '11px monospace';
+        ctx.fillText(\`Grid: \${this.mapComp?.width || 0}x\${this.mapComp?.height || 0}\`, 10, 20);
+        ctx.fillText(\`FPS: \${this.fps}\`, 10, 32);
+        const agent = entities[0]?.getComponent(PathfindingAgentComponent);
+        ctx.fillText(\`Path: \${agent?.path.length || 0} nodes\`, 10, 44);
+    }
+}
+
+// ============================================
+// 移动系统
+// ============================================
+
+@ECSSystem('Movement', { updateOrder: 50 })
+class MovementSystem extends EntitySystem {
+    mapComp: PathfindingMapComponent | null = null;
+
+    constructor() {
+        super(Matcher.all(PathfindingAgentComponent));
+    }
+
+    process(entities) {
+        if (!this.mapComp) {
+            const mapEntities = this.scene.entities.findEntitiesWithComponent(PathfindingMapComponent);
+            if (mapEntities.length > 0) {
+                this.mapComp = mapEntities[0].getComponent(PathfindingMapComponent);
+            }
+        }
+        if (!this.mapComp?.map) return;
+
+        const cellW = WIDTH / this.mapComp.map.width;
+        const cellH = HEIGHT / this.mapComp.map.height;
+        const dt = Time.deltaTime;
+        const moveSpeed = params.speed * dt;
+
+        for (const entity of entities) {
+            const agent = entity.getComponent(PathfindingAgentComponent);
+
+            if (!agent.hasValidPath() || agent.isPathComplete()) continue;
+
+            const waypoint = agent.getNextWaypoint();
+            if (!waypoint) continue;
+
+            const dx = waypoint.x - agent.x;
+            const dy = waypoint.y - agent.y;
+            const dist = Math.sqrt(dx * dx + dy * dy);
+
+            if (dist < 0.1) {
+                agent.x = waypoint.x;
+                agent.y = waypoint.y;
+                agent.advanceWaypoint();
+            } else {
+                const moveRatio = Math.min(moveSpeed / dist, 1);
+                agent.x += dx * moveRatio;
+                agent.y += dy * moveRatio;
+            }
+        }
+    }
+}
+
+// ============================================
+// 场景
+// ============================================
+
+class AStarDemoScene extends Scene {
+    mapEntity: any;
+    agentEntity: any;
+
+    initialize() {
+        this.name = 'AStarDemo';
+        this.addSystem(new PathfindingSystem());
+        this.addSystem(new MovementSystem());
+        this.addSystem(new RenderSystem(ctx));
+    }
+
+    onStart() {
+        this.loadScenario('maze');
+    }
+
+    loadScenario(type: string) {
+        console.log('loadScenario called:', type);
+
+        // 清除现有实体（使用正确的API）
+        if (this.mapEntity) {
+            this.mapEntity.destroy();
+            this.mapEntity = null;
+        }
+        if (this.agentEntity) {
+            this.agentEntity.destroy();
+            this.agentEntity = null;
+        }
+
+        // 重置渲染系统的地图引用
+        for (const system of this.systems) {
+            if (system.mapComp) system.mapComp = null;
+        }
+
+        const gridSize = params.gridSize;
+
+        // 创建地图实体
+        this.mapEntity = this.createEntity('Map');
+        const mapComp = this.mapEntity.addComponent(new PathfindingMapComponent());
+        mapComp.width = gridSize;
+        mapComp.height = Math.floor(gridSize * HEIGHT / WIDTH);
+        mapComp.allowDiagonal = params.diagonal === 1;
+        mapComp.avoidCorners = true;
+        mapComp.enableSmoothing = false;
+
+        // 创建代理
+        this.agentEntity = this.createEntity('Agent');
+        const agent = this.agentEntity.addComponent(new PathfindingAgentComponent());
+        const visual = this.agentEntity.addComponent(new VisualComponent());
+        visual.color = '#00d4ff';
+
+        // 等待地图初始化后生成障碍物
+        setTimeout(() => {
+            if (!mapComp.map) return;
+
+            const generators = {
+                maze: () => this.generateMaze(mapComp),
+                random: () => this.generateRandom(mapComp),
+                rooms: () => this.generateRooms(mapComp),
+                spiral: () => this.generateSpiral(mapComp)
+            };
+            generators[type]?.();
+
+            // 找到起点和终点（spiral 场景特殊处理：从中心到边缘）
+            let start, end;
+            if (type === 'spiral') {
+                const cx = Math.floor(mapComp.width / 2);
+                const cy = Math.floor(mapComp.height / 2);
+                start = { x: cx, y: cy };  // 中心
+                end = this.findWalkable(mapComp, 1, 1);  // 边缘
+            } else {
+                start = this.findWalkable(mapComp, 1, 1);
+                end = this.findWalkable(mapComp, mapComp.width - 2, mapComp.height - 2);
+            }
+
+            agent.x = start.x;
+            agent.y = start.y;
+            agent.requestPathTo(end.x, end.y);
+        }, 100);
+    }
+
+    findWalkable(mapComp, preferX, preferY) {
+        if (mapComp.isWalkable(preferX, preferY)) return { x: preferX, y: preferY };
+        for (let r = 1; r < 10; r++) {
+            for (let dx = -r; dx <= r; dx++) {
+                for (let dy = -r; dy <= r; dy++) {
+                    const x = preferX + dx, y = preferY + dy;
+                    if (x >= 0 && x < mapComp.width && y >= 0 && y < mapComp.height) {
+                        if (mapComp.isWalkable(x, y)) return { x, y };
+                    }
+                }
+            }
+        }
+        return { x: 1, y: 1 };
+    }
+
+    generateMaze(mapComp) {
+        const w = mapComp.width, h = mapComp.height;
+        // 填充所有为墙
+        for (let y = 0; y < h; y++) {
+            for (let x = 0; x < w; x++) {
+                mapComp.setWalkable(x, y, false);
+            }
+        }
+        // 递归分割生成迷宫
+        const carve = (x, y) => {
+            mapComp.setWalkable(x, y, true);
+            const dirs = [[0,-2],[0,2],[-2,0],[2,0]].sort(() => Math.random() - 0.5);
+            for (const [dx, dy] of dirs) {
+                const nx = x + dx, ny = y + dy;
+                if (nx > 0 && nx < w-1 && ny > 0 && ny < h-1 && !mapComp.isWalkable(nx, ny)) {
+                    mapComp.setWalkable(x + dx/2, y + dy/2, true);
+                    carve(nx, ny);
+                }
+            }
+        };
+        carve(1, 1);
+    }
+
+    generateRandom(mapComp) {
+        const w = mapComp.width, h = mapComp.height;
+        const rate = params.obstacleRate / 100;
+        for (let y = 0; y < h; y++) {
+            for (let x = 0; x < w; x++) {
+                if (x === 1 && y === 1) continue;
+                if (x === w-2 && y === h-2) continue;
+                mapComp.setWalkable(x, y, Math.random() > rate);
+            }
+        }
+    }
+
+    generateRooms(mapComp) {
+        const w = mapComp.width, h = mapComp.height;
+        // 全部可通行
+        for (let y = 0; y < h; y++) {
+            for (let x = 0; x < w; x++) {
+                mapComp.setWalkable(x, y, true);
+            }
+        }
+        // 生成房间墙壁
+        const roomW = Math.floor(w / 4);
+        const roomH = Math.floor(h / 3);
+        for (let ry = 0; ry < 3; ry++) {
+            for (let rx = 0; rx < 4; rx++) {
+                const bx = rx * roomW, by = ry * roomH;
+                // 画墙
+                for (let x = bx; x < bx + roomW && x < w; x++) {
+                    if (by < h) mapComp.setWalkable(x, by, false);
+                    if (by + roomH - 1 < h) mapComp.setWalkable(x, by + roomH - 1, false);
+                }
+                for (let y = by; y < by + roomH && y < h; y++) {
+                    if (bx < w) mapComp.setWalkable(bx, y, false);
+                    if (bx + roomW - 1 < w) mapComp.setWalkable(bx + roomW - 1, y, false);
+                }
+                // 开门
+                const doorX = bx + Math.floor(roomW / 2);
+                const doorY = by + Math.floor(roomH / 2);
+                if (doorX < w && by < h) mapComp.setWalkable(doorX, by, true);
+                if (doorX < w && by + roomH - 1 < h) mapComp.setWalkable(doorX, by + roomH - 1, true);
+                if (bx < w && doorY < h) mapComp.setWalkable(bx, doorY, true);
+                if (bx + roomW - 1 < w && doorY < h) mapComp.setWalkable(bx + roomW - 1, doorY, true);
+            }
+        }
+    }
+
+    generateSpiral(mapComp) {
+        const w = mapComp.width, h = mapComp.height;
+        const cx = Math.floor(w / 2), cy = Math.floor(h / 2);
+        const maxDist = Math.min(cx, cy) - 1;
+
+        // 先全部设为可行走
+        for (let y = 0; y < h; y++) {
+            for (let x = 0; x < w; x++) {
+                mapComp.setWalkable(x, y, true);
+            }
+        }
+
+        // 生成螺旋墙壁，但保留通道
+        for (let ring = 3; ring < maxDist; ring += 3) {
+            // 画圆环墙壁，但留一个开口
+            const openingAngle = (ring * 0.5) % (Math.PI * 2);
+            for (let angle = 0; angle < Math.PI * 2; angle += 0.1) {
+                // 每圈留一个 60 度的开口
+                const angleDiff = Math.abs(((angle - openingAngle + Math.PI) % (Math.PI * 2)) - Math.PI);
+                if (angleDiff > 0.5) {
+                    const x = Math.round(cx + Math.cos(angle) * ring);
+                    const y = Math.round(cy + Math.sin(angle) * ring);
+                    if (x >= 0 && x < w && y >= 0 && y < h) {
+                        mapComp.setWalkable(x, y, false);
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ============================================
+// 初始化
+// ============================================
+
+Core.create({ debug: false });
+const demoScene = new AStarDemoScene();
+Core.setScene(demoScene);
+
+// 暴露场景给 DemoPlayground 以支持场景切换
+window.__demoScene = demoScene;
+
+let lastTime = performance.now();
+
+function gameLoop() {
+    const now = performance.now();
+    const dt = Math.min((now - lastTime) / 1000, 0.1);
+    lastTime = now;
+    Core.update(dt);
+    requestAnimationFrame(gameLoop);
+}
+
+gameLoop();`;
+
+这是一个使用 **ECS 架构** 实现的 A* 网格寻路交互式演示。
+
+点击 **Run** 启动模拟，使用工具栏切换不同的地图场景，调整参数观察寻路效果。
+
+<DemoPlayground
+    client:load
+    title="A* 寻路 - ECS 架构"
+    code={astarDemoCode}
+    canvasWidth={580}
+    canvasHeight={380}
+    scenes={astarScenes}
+    params={astarParams}
+/>
+
+<script is:inline src="/esengine/js/esengine.iife.js"></script>
+
+## 场景说明
+
+- **迷宫** - 使用递归分割算法生成的迷宫，测试长路径寻路
+- **随机障碍** - 随机分布的障碍物，可调整密度
+- **房间** - 模拟房间布局，测试门和走廊
+- **螺旋** - 螺旋形障碍物，测试复杂路径
+
+## 相关文档
+
+- [寻路系统 API](/esengine/modules/pathfinding) - 完整 API 文档和使用指南
+- [ORCA 局部避让](/esengine/modules/pathfinding/local-avoidance) - 多代理避让
+- [快速开始](/esengine/guide/getting-started) - ECS 框架入门

--- a/docs/src/content/docs/examples/hpa-pathfinding-demo.mdx
+++ b/docs/src/content/docs/examples/hpa-pathfinding-demo.mdx
@@ -1,0 +1,452 @@
+---
+title: "HPA* 分层寻路"
+description: "分层寻路 A* (Hierarchical Pathfinding A*) 演示，适用于超大地图"
+---
+
+import DemoPlayground from '../../../components/DemoPlayground.vue';
+
+export const hpaScenes = [
+    { id: 'small', label: 'S', name: '小地图 (100x65)' },
+    { id: 'medium', label: 'M', name: '中地图 (250x163)' },
+    { id: 'large', label: 'L', name: '大地图 (500x325)' },
+    { id: 'huge', label: 'XL', name: '超大地图 (1000x650)' }
+];
+
+export const hpaParams = [
+    { id: 'clusterSize', label: 'Cluster', desc: '集群大小（边长）', value: 64, min: 10, max: 100, step: 10 },
+    { id: 'obstacleRate', label: 'Obstacles', desc: '障碍物密度（%）', value: 15, min: 0, max: 100, step: 1 },
+    { id: 'showClusters', label: 'Clusters', desc: '显示集群边界（0=否，1=是）', value: 1, min: 0, max: 1, step: 1 }
+];
+
+export const hpaDemoCode = `// HPA* 分层寻路演示
+// ============================================
+// 对比 HPA* 与标准 A* 在超大地图上的性能差异
+
+const {
+    GridMap, createGridMap,
+    AStarPathfinder, HPAPathfinder,
+    octileDistance
+} = ESEngine;
+
+const WIDTH = 580, HEIGHT = 380;
+
+const params = window.__demoParams || {
+    clusterSize: 20, obstacleRate: 15, showClusters: 1
+};
+
+let gridMap = null;
+let mapWidth = 100, mapHeight = 65;
+let startPos = { x: 5, y: 5 };
+let endPos = { x: 0, y: 0 };
+
+// 性能结果
+let results = {
+    astar: { time: 0, nodes: 0, pathLen: 0, path: [] },
+    hpa: { time: 0, nodes: 0, pathLen: 0, path: [], stats: null, preprocessTime: 0, cachedTime: 0 }
+};
+
+let hpaPathfinder = null;
+let isSearching = false;
+
+// ============================================
+// 渲染
+// ============================================
+
+function render(ctx) {
+    if (!gridMap) return;
+
+    const cellW = WIDTH / mapWidth;
+    const cellH = HEIGHT / mapHeight;
+    const drawCells = cellW >= 2;  // 只有当单元格足够大时才绘制
+
+    // 清屏
+    ctx.fillStyle = '#16213e';
+    ctx.fillRect(0, 0, WIDTH, HEIGHT);
+
+    // 绘制集群边界
+    if (params.showClusters === 1) {
+        ctx.strokeStyle = 'rgba(100, 200, 255, 0.4)';
+        ctx.lineWidth = 1;
+        const cs = params.clusterSize;
+        for (let cx = 0; cx <= Math.ceil(mapWidth / cs); cx++) {
+            const x = cx * cs * cellW;
+            ctx.beginPath();
+            ctx.moveTo(x, 0);
+            ctx.lineTo(x, HEIGHT);
+            ctx.stroke();
+        }
+        for (let cy = 0; cy <= Math.ceil(mapHeight / cs); cy++) {
+            const y = cy * cs * cellH;
+            ctx.beginPath();
+            ctx.moveTo(0, y);
+            ctx.lineTo(WIDTH, y);
+            ctx.stroke();
+        }
+    }
+
+    // 绘制障碍物（仅当单元格足够大时）
+    if (drawCells) {
+        ctx.fillStyle = '#2d4263';
+        for (let y = 0; y < mapHeight; y++) {
+            for (let x = 0; x < mapWidth; x++) {
+                if (!gridMap.isWalkable(x, y)) {
+                    ctx.fillRect(x * cellW, y * cellH, cellW - 0.5, cellH - 0.5);
+                }
+            }
+        }
+    } else {
+        // 大地图：使用采样绘制
+        ctx.fillStyle = '#2d4263';
+        const sampleRate = Math.ceil(mapWidth / WIDTH * 2);
+        for (let sy = 0; sy < HEIGHT; sy += 2) {
+            for (let sx = 0; sx < WIDTH; sx += 2) {
+                const gx = Math.floor(sx / cellW);
+                const gy = Math.floor(sy / cellH);
+                if (gx < mapWidth && gy < mapHeight && !gridMap.isWalkable(gx, gy)) {
+                    ctx.fillRect(sx, sy, 2, 2);
+                }
+            }
+        }
+    }
+
+    // 绘制 A* 路径
+    if (results.astar.path.length > 1) {
+        ctx.strokeStyle = 'rgba(255, 107, 107, 0.7)';
+        ctx.lineWidth = drawCells ? 2 : 3;
+        ctx.beginPath();
+        ctx.moveTo(results.astar.path[0].x * cellW + cellW/2, results.astar.path[0].y * cellH + cellH/2);
+        for (let i = 1; i < results.astar.path.length; i++) {
+            ctx.lineTo(results.astar.path[i].x * cellW + cellW/2, results.astar.path[i].y * cellH + cellH/2);
+        }
+        ctx.stroke();
+    }
+
+    // 绘制 HPA* 路径
+    if (results.hpa.path.length > 1) {
+        ctx.strokeStyle = 'rgba(78, 205, 196, 0.9)';
+        ctx.lineWidth = drawCells ? 3 : 4;
+        ctx.beginPath();
+        ctx.moveTo(results.hpa.path[0].x * cellW + cellW/2, results.hpa.path[0].y * cellH + cellH/2);
+        for (let i = 1; i < results.hpa.path.length; i++) {
+            ctx.lineTo(results.hpa.path[i].x * cellW + cellW/2, results.hpa.path[i].y * cellH + cellH/2);
+        }
+        ctx.stroke();
+    }
+
+    // 绘制起点终点
+    const pointSize = Math.max(4, Math.min(cellW, cellH) * 0.5);
+    ctx.fillStyle = '#00d4ff';
+    ctx.beginPath();
+    ctx.arc(startPos.x * cellW + cellW/2, startPos.y * cellH + cellH/2, pointSize, 0, Math.PI * 2);
+    ctx.fill();
+
+    ctx.fillStyle = '#ff6b6b';
+    ctx.beginPath();
+    ctx.arc(endPos.x * cellW + cellW/2, endPos.y * cellH + cellH/2, pointSize, 0, Math.PI * 2);
+    ctx.fill();
+
+    // HUD - 性能对比
+    const panelX = 5, panelY = 5;
+    ctx.fillStyle = 'rgba(0,0,0,0.85)';
+    ctx.fillRect(panelX, panelY, 240, 155);
+
+    ctx.font = 'bold 11px monospace';
+    ctx.fillStyle = '#fff';
+    ctx.fillText('HPA* vs A* Performance', panelX + 5, panelY + 15);
+
+    ctx.font = '10px monospace';
+    ctx.fillStyle = '#888';
+    const totalCells = (mapWidth * mapHeight / 1000).toFixed(0);
+    ctx.fillText(\`Map: \${mapWidth}x\${mapHeight} (\${totalCells}K cells)\`, panelX + 5, panelY + 30);
+
+    // A* 结果
+    ctx.fillStyle = '#ff6b6b';
+    ctx.fillText('Standard A*:', panelX + 5, panelY + 47);
+    ctx.fillStyle = '#ccc';
+    if (results.astar.time > 0) {
+        ctx.fillText(\`  Time: \${results.astar.time.toFixed(2)}ms\`, panelX + 5, panelY + 60);
+        ctx.fillText(\`  Nodes: \${results.astar.nodes.toLocaleString()}\`, panelX + 5, panelY + 72);
+    } else {
+        ctx.fillText('  (searching...)', panelX + 5, panelY + 60);
+    }
+
+    // HPA* 结果
+    ctx.fillStyle = '#4ecdc4';
+    ctx.fillText('HPA* (Lazy Intra-Edges):', panelX + 5, panelY + 87);
+    ctx.fillStyle = '#ccc';
+    if (results.hpa.time > 0) {
+        ctx.fillText(\`  Preprocess: \${results.hpa.preprocessTime.toFixed(1)}ms\`, panelX + 5, panelY + 100);
+        ctx.fillText(\`  1st Query: \${results.hpa.time.toFixed(2)}ms\`, panelX + 5, panelY + 112);
+        if (results.hpa.cachedTime > 0) {
+            ctx.fillText(\`  Cached: \${results.hpa.cachedTime.toFixed(2)}ms\`, panelX + 5, panelY + 124);
+        }
+        if (results.hpa.stats) {
+            ctx.fillText(\`  Clusters: \${results.hpa.stats.clusters}, Nodes: \${results.hpa.stats.abstractNodes}\`, panelX + 5, panelY + 136);
+        }
+    } else {
+        ctx.fillText('  (searching...)', panelX + 5, panelY + 100);
+    }
+
+    // 性能提升
+    if (results.astar.time > 0 && results.hpa.cachedTime > 0) {
+        const speedup = results.astar.time / results.hpa.cachedTime;
+        ctx.fillStyle = speedup > 1 ? '#4ecdc4' : '#ff6b6b';
+        ctx.font = 'bold 12px monospace';
+        ctx.fillText(\`Speedup (cached): \${speedup.toFixed(0)}x\`, panelX + 5, panelY + 151);
+    }
+
+    // 图例
+    const legendX = WIDTH - 90, legendY = 5;
+    ctx.fillStyle = 'rgba(0,0,0,0.85)';
+    ctx.fillRect(legendX, legendY, 85, 55);
+    ctx.font = '9px monospace';
+
+    ctx.fillStyle = '#ff6b6b';
+    ctx.fillRect(legendX + 5, legendY + 10, 15, 3);
+    ctx.fillStyle = '#fff';
+    ctx.fillText('A*', legendX + 25, legendY + 15);
+
+    ctx.fillStyle = '#4ecdc4';
+    ctx.fillRect(legendX + 5, legendY + 25, 15, 3);
+    ctx.fillStyle = '#fff';
+    ctx.fillText('HPA*', legendX + 25, legendY + 30);
+
+    ctx.fillStyle = 'rgba(100, 200, 255, 0.5)';
+    ctx.fillRect(legendX + 5, legendY + 40, 15, 3);
+    ctx.fillStyle = '#fff';
+    ctx.fillText('Cluster', legendX + 25, legendY + 45);
+
+    // 大地图提示
+    if (!drawCells) {
+        ctx.fillStyle = 'rgba(0,0,0,0.7)';
+        ctx.fillRect(WIDTH/2 - 80, HEIGHT - 25, 160, 20);
+        ctx.fillStyle = '#888';
+        ctx.font = '10px monospace';
+        ctx.fillText('Large map: simplified view', WIDTH/2 - 70, HEIGHT - 10);
+    }
+}
+
+// ============================================
+// 寻路
+// ============================================
+
+async function runPathfinding() {
+    if (!gridMap || isSearching) return;
+    isSearching = true;
+
+    // 重置结果
+    results.astar = { time: 0, nodes: 0, pathLen: 0, path: [] };
+    results.hpa = { time: 0, nodes: 0, pathLen: 0, path: [], stats: null, preprocessTime: 0, cachedTime: 0 };
+
+    // 根据地图大小调整 maxNodes，确保大地图能完整搜索
+    const maxNodes = mapWidth * mapHeight;
+    const options = { allowDiagonal: true, heuristic: octileDistance, maxNodes };
+
+    // 延迟执行以显示 UI 更新
+    await new Promise(r => setTimeout(r, 50));
+
+    // 标准 A*
+    const astar = new AStarPathfinder(gridMap);
+    let t0 = performance.now();
+    let result = astar.findPath(startPos.x, startPos.y, endPos.x, endPos.y, options);
+    results.astar = {
+        time: performance.now() - t0,
+        nodes: result.nodesSearched,
+        pathLen: result.path.length,
+        path: result.path
+    };
+
+    await new Promise(r => setTimeout(r, 10));
+
+    // HPA* with lazy intra-edges (default)
+    hpaPathfinder = new HPAPathfinder(gridMap, {
+        clusterSize: params.clusterSize,
+        maxEntranceWidth: 16,
+        cacheInternalPaths: true,
+        lazyIntraEdges: true  // 延迟计算 intra-edges
+    });
+
+    // 预处理（现在非常快，因为不计算真实路径）
+    t0 = performance.now();
+    hpaPathfinder.preprocess();
+    const preprocessTime = performance.now() - t0;
+
+    // 第一次查询（会触发 lazy 路径计算）
+    t0 = performance.now();
+    result = hpaPathfinder.findPath(startPos.x, startPos.y, endPos.x, endPos.y, options);
+    const firstQueryTime = performance.now() - t0;
+
+    // 第二次查询（使用缓存，应该非常快）
+    t0 = performance.now();
+    hpaPathfinder.findPath(startPos.x, startPos.y, endPos.x, endPos.y, options);
+    const cachedTime = performance.now() - t0;
+
+    results.hpa = {
+        time: firstQueryTime,
+        nodes: result.nodesSearched,
+        pathLen: result.path.length,
+        path: result.path,
+        stats: hpaPathfinder.getStats(),
+        preprocessTime: preprocessTime,
+        cachedTime: cachedTime
+    };
+
+    isSearching = false;
+}
+
+// ============================================
+// 地图生成
+// ============================================
+
+function generateMap(size) {
+    const sizes = {
+        small: { w: 100, h: 65 },
+        medium: { w: 250, h: 163 },
+        large: { w: 500, h: 325 },
+        huge: { w: 1000, h: 650 }
+    };
+
+    const s = sizes[size] || sizes.small;
+    mapWidth = s.w;
+    mapHeight = s.h;
+
+    gridMap = createGridMap(mapWidth, mapHeight);
+    hpaPathfinder = null;
+
+    // 生成随机障碍
+    const rate = params.obstacleRate / 100;
+    for (let y = 0; y < mapHeight; y++) {
+        for (let x = 0; x < mapWidth; x++) {
+            if (Math.random() < rate) {
+                gridMap.setWalkable(x, y, false);
+            }
+        }
+    }
+
+    // 确保起点和终点周围畅通
+    const clearRadius = Math.max(3, Math.floor(Math.min(mapWidth, mapHeight) / 20));
+    const clearArea = (cx, cy, r) => {
+        for (let dy = -r; dy <= r; dy++) {
+            for (let dx = -r; dx <= r; dx++) {
+                const x = cx + dx, y = cy + dy;
+                if (x >= 0 && x < mapWidth && y >= 0 && y < mapHeight) {
+                    gridMap.setWalkable(x, y, true);
+                }
+            }
+        }
+    };
+
+    startPos = { x: clearRadius + 2, y: clearRadius + 2 };
+    endPos = { x: mapWidth - clearRadius - 3, y: mapHeight - clearRadius - 3 };
+    clearArea(startPos.x, startPos.y, clearRadius);
+    clearArea(endPos.x, endPos.y, clearRadius);
+
+    // 重置结果
+    results.astar = { time: 0, nodes: 0, pathLen: 0, path: [] };
+    results.hpa = { time: 0, nodes: 0, pathLen: 0, path: [], stats: null, preprocessTime: 0, cachedTime: 0 };
+
+    runPathfinding();
+}
+
+// ============================================
+// 初始化
+// ============================================
+
+generateMap('small');
+
+// 点击设置起点/终点
+let clickMode = 'start';
+canvas.addEventListener('click', (e) => {
+    if (isSearching) return;
+
+    const rect = canvas.getBoundingClientRect();
+    const mx = (e.clientX - rect.left) * (canvas.width / rect.width);
+    const my = (e.clientY - rect.top) * (canvas.height / rect.height);
+    const cellW = WIDTH / mapWidth;
+    const cellH = HEIGHT / mapHeight;
+    const gx = Math.floor(mx / cellW);
+    const gy = Math.floor(my / cellH);
+
+    if (gx >= 0 && gx < mapWidth && gy >= 0 && gy < mapHeight && gridMap.isWalkable(gx, gy)) {
+        if (clickMode === 'start') {
+            startPos = { x: gx, y: gy };
+            clickMode = 'end';
+        } else {
+            endPos = { x: gx, y: gy };
+            clickMode = 'start';
+            runPathfinding();
+        }
+    }
+});
+
+// 场景切换
+window.__demoScene = {
+    loadScenario: (type) => {
+        generateMap(type);
+    }
+};
+
+// 游戏循环
+function gameLoop() {
+    render(ctx);
+    requestAnimationFrame(gameLoop);
+}
+
+gameLoop();`;
+
+这是一个 **HPA* (分层寻路 A*)** 演示，展示在**超大地图**上的性能优势。
+
+点击 **Run** 开始，使用工具栏切换不同地图大小，观察 HPA* 与标准 A* 的性能对比。
+
+**HPA* 原理：**
+1. 将地图划分为**集群 (Clusters)**
+2. 在集群边界检测**入口点 (Entrances)**
+3. 构建**抽象图**连接入口点
+4. 先在抽象图上寻路，再细化为详细路径
+
+**Lazy Intra-Edges 优化：**
+- 预处理速度提升 ~1000 倍（1000x650 地图：52ms vs 68s）
+- 首次查询按需计算实际路径
+- 后续查询使用缓存路径（极快）
+
+<DemoPlayground
+    client:load
+    title="HPA* 分层寻路 - 超大地图优化"
+    code={hpaDemoCode}
+    canvasWidth={580}
+    canvasHeight={380}
+    scenes={hpaScenes}
+    params={hpaParams}
+/>
+
+<script is:inline src="/esengine/js/esengine.iife.js"></script>
+
+## 性能对比
+
+| 地图大小 | 单元格数 | A* 适用性 | HPA* 优势 |
+|----------|----------|-----------|-----------|
+| 100x65 | ~6,500 | ✅ 良好 | 轻微 |
+| 250x163 | ~40,000 | ⚠️ 较慢 | 明显 |
+| 500x325 | ~162,500 | ❌ 很慢 | **显著** |
+| 1000x650 | ~650,000 | ❌ 极慢 | **巨大** |
+
+## 适用场景
+
+- **开放世界游戏** - 大型连续地图（如 1000x1000+）
+- **RTS 游戏** - 需要频繁寻路的大量单位
+- **城市模拟** - 复杂的道路网络
+- **服务器端寻路** - 需要快速响应的后端
+
+## 参数说明
+
+| 参数 | 说明 |
+|------|------|
+| **Cluster** | 集群大小，越大预处理越快但精度降低 |
+| **Obstacles** | 障碍物密度 |
+| **Clusters** | 是否显示集群边界线 |
+
+## 相关文档
+
+- [算法对比演示](/esengine/examples/algorithm-comparison-demo) - 比较 A*、双向 A*、JPS
+- [搜索可视化](/esengine/examples/search-visualization-demo) - A* 搜索过程可视化
+- [寻路系统 API](/esengine/modules/pathfinding) - 完整文档

--- a/docs/src/content/docs/examples/index.md
+++ b/docs/src/content/docs/examples/index.md
@@ -6,15 +6,29 @@ title: "示例"
 
 ## 🎮 互动演示
 
-### [Worker系统演示](./worker-system-demo)
-- **功能**: 展示Worker多线程物理计算和渲染优化
-- **特性**: 1000+粒子实时物理模拟、碰撞检测、性能对比
-- **技术点**: SharedArrayBuffer、Canvas 2D优化、实体生命周期管理
+### 寻路系统
 
-### [ORCA 局部避让演示](./orca-avoidance-demo)
+#### [A* 寻路演示](./astar-pathfinding-demo)
+- **功能**: 网格寻路可视化
+- **特性**: 迷宫生成、随机障碍、房间布局、螺旋地图
+- **技术点**: A* 算法、增量寻路、ECS 架构
+
+#### [多代理寻路演示](./multi-agent-pathfinding-demo)
+- **功能**: 多代理同时寻路与避让
+- **特性**: A* 寻路 + ORCA 避让结合、多种场景预设
+- **技术点**: PathfindingSystem、LocalAvoidanceSystem 协作
+
+#### [ORCA 局部避让演示](./orca-avoidance-demo)
 - **功能**: 多代理碰撞避让 (ORCA 算法)
-- **特性**: 50-200代理实时避让、多种场景预设、参数调节
-- **技术点**: KDTree空间索引、线性规划求解、ECS架构
+- **特性**: 50-500 代理实时避让、多种场景预设、参数调节
+- **技术点**: KDTree 空间索引、线性规划求解、ECS 架构
+
+### 系统演示
+
+#### [Worker 系统演示](./worker-system-demo)
+- **功能**: 展示 Worker 多线程物理计算和渲染优化
+- **特性**: 1000+ 粒子实时物理模拟、碰撞检测、性能对比
+- **技术点**: SharedArrayBuffer、Canvas 2D 优化、实体生命周期管理
 
 ## 🔗 外部示例
 

--- a/docs/src/content/docs/examples/multi-agent-pathfinding-demo.mdx
+++ b/docs/src/content/docs/examples/multi-agent-pathfinding-demo.mdx
@@ -1,0 +1,510 @@
+---
+title: "多代理寻路演示"
+description: "使用 ECS 架构实现的多代理寻路与避让交互式演示"
+---
+
+import DemoPlayground from '../../../components/DemoPlayground.vue';
+
+export const multiAgentScenes = [
+    { id: 'swap', label: '⇄', name: '交换位置' },
+    { id: 'gather', label: '◉', name: '聚集' },
+    { id: 'scatter', label: '✦', name: '分散' },
+    { id: 'patrol', label: '↻', name: '巡逻' }
+];
+
+export const multiAgentParams = [
+    { id: 'agentCount', label: 'Agents', desc: '代理数量', value: 8, min: 2, max: 20, step: 2 },
+    { id: 'speed', label: 'Speed', desc: '移动速度（网格/秒）', value: 5, min: 1, max: 15, step: 1 },
+    { id: 'avoidance', label: 'Avoidance', desc: '是否启用局部避让（0=否，1=是）', value: 1, min: 0, max: 1, step: 1 },
+    { id: 'gridSize', label: 'Grid', desc: '网格大小', value: 30, min: 20, max: 50, step: 5 }
+];
+
+export const multiAgentDemoCode = `// 多代理寻路 - ECS 架构演示
+// ============================================
+// 展示多个代理同时寻路并使用 ORCA 避让
+
+const {
+    Core, Scene, Component, EntitySystem, Matcher, Time,
+    ECSComponent, ECSSystem,
+    PathfindingAgentComponent, PathfindingMapComponent, PathfindingSystem,
+    AvoidanceAgentComponent, AvoidanceWorldComponent, LocalAvoidanceSystem
+} = ESEngine;
+
+const WIDTH = 580, HEIGHT = 380;
+
+const params = window.__demoParams || {
+    agentCount: 8, speed: 5, avoidance: 1, gridSize: 30
+};
+
+// 避让世界组件引用
+let worldComponent: any = null;
+
+// ============================================
+// 组件定义
+// ============================================
+
+@ECSComponent('AgentVisual')
+class AgentVisualComponent extends Component {
+    color = '#00d4ff';
+    targetColor = '#ff6b6b';
+    index = 0;
+}
+
+// ============================================
+// 渲染系统
+// ============================================
+
+@ECSSystem('Render', { updateOrder: 100 })
+class RenderSystem extends EntitySystem {
+    ctx: CanvasRenderingContext2D;
+    mapComp: PathfindingMapComponent | null = null;
+    fps = 0; frameCount = 0; lastFpsTime = 0;
+
+    constructor(context: CanvasRenderingContext2D) {
+        super(Matcher.all(PathfindingAgentComponent, AgentVisualComponent));
+        this.ctx = context;
+    }
+
+    process(entities) {
+        const ctx = this.ctx;
+
+        // 清屏
+        ctx.fillStyle = '#16213e';
+        ctx.fillRect(0, 0, WIDTH, HEIGHT);
+
+        // 查找地图组件
+        if (!this.mapComp) {
+            const mapEntities = this.scene.entities.findEntitiesWithComponent(PathfindingMapComponent);
+            if (mapEntities.length > 0) {
+                this.mapComp = mapEntities[0].getComponent(PathfindingMapComponent);
+            }
+        }
+
+        const map = this.mapComp?.map;
+        if (!map) return;
+
+        const cellW = WIDTH / map.width;
+        const cellH = HEIGHT / map.height;
+
+        // 绘制障碍物
+        ctx.fillStyle = '#2d4263';
+        for (let y = 0; y < map.height; y++) {
+            for (let x = 0; x < map.width; x++) {
+                if (!map.isWalkable(x, y)) {
+                    ctx.fillRect(x * cellW + 1, y * cellH + 1, cellW - 2, cellH - 2);
+                }
+            }
+        }
+
+        // FPS
+        this.frameCount++;
+        const now = performance.now();
+        if (now - this.lastFpsTime >= 1000) {
+            this.fps = this.frameCount;
+            this.frameCount = 0;
+            this.lastFpsTime = now;
+        }
+
+        // 绘制代理（agent.x/y 是网格坐标，需要转换为像素）
+        for (const entity of entities) {
+            const agent = entity.getComponent(PathfindingAgentComponent);
+            const visual = entity.getComponent(AgentVisualComponent);
+
+            // 绘制路径（路径点是网格坐标，需要转换）
+            if (agent.path.length > agent.pathIndex) {
+                ctx.strokeStyle = visual.color + '40';
+                ctx.lineWidth = 2;
+                ctx.beginPath();
+                ctx.moveTo(agent.x * cellW + cellW/2, agent.y * cellH + cellH/2);
+                for (let i = agent.pathIndex; i < agent.path.length; i++) {
+                    const p = agent.path[i];
+                    ctx.lineTo(p.x * cellW + cellW/2, p.y * cellH + cellH/2);
+                }
+                ctx.stroke();
+            }
+
+            // 绘制目标（targetX/Y 是网格坐标）
+            ctx.fillStyle = visual.targetColor + '60';
+            ctx.beginPath();
+            ctx.arc(agent.targetX * cellW + cellW/2, agent.targetY * cellH + cellH/2, 5, 0, Math.PI * 2);
+            ctx.fill();
+
+            // 绘制代理（agent.x/y 是网格坐标，转为像素）
+            const x = agent.x * cellW + cellW/2;
+            const y = agent.y * cellH + cellH/2;
+
+            // 光晕
+            const gradient = ctx.createRadialGradient(x, y, 0, x, y, 15);
+            gradient.addColorStop(0, visual.color);
+            gradient.addColorStop(1, 'transparent');
+            ctx.beginPath();
+            ctx.arc(x, y, 15, 0, Math.PI * 2);
+            ctx.fillStyle = gradient;
+            ctx.fill();
+
+            // 代理
+            ctx.beginPath();
+            ctx.arc(x, y, 7, 0, Math.PI * 2);
+            ctx.fillStyle = visual.color;
+            ctx.fill();
+
+            // 编号
+            ctx.fillStyle = '#fff';
+            ctx.font = '10px monospace';
+            ctx.textAlign = 'center';
+            ctx.fillText(String(visual.index + 1), x, y + 3);
+        }
+
+        // HUD
+        ctx.fillStyle = 'rgba(0,0,0,0.6)';
+        ctx.fillRect(5, 5, 150, 50);
+        ctx.fillStyle = '#00d4ff';
+        ctx.font = '11px monospace';
+        ctx.textAlign = 'left';
+        ctx.fillText(\`Agents: \${entities.length}\`, 10, 20);
+        ctx.fillText(\`Avoidance: \${params.avoidance ? 'ON' : 'OFF'}\`, 10, 32);
+        ctx.fillText(\`FPS: \${this.fps}\`, 10, 44);
+    }
+}
+
+// ============================================
+// 期望速度系统（在 LocalAvoidanceSystem 之前运行）
+// 每帧重置并设置朝向下一路径点的期望速度
+// 因为 LocalAvoidanceSystem 只在 preferredVelocity=0 时才自动设置
+// ============================================
+
+@ECSSystem('PreferredVelocity', { updateOrder: 45 })
+class PreferredVelocitySystem extends EntitySystem {
+    constructor() {
+        super(Matcher.all(PathfindingAgentComponent, AvoidanceAgentComponent));
+    }
+
+    process(entities) {
+        for (const entity of entities) {
+            const agent = entity.getComponent(PathfindingAgentComponent);
+            const avoid = entity.getComponent(AvoidanceAgentComponent);
+
+            // 先同步位置（LocalAvoidanceSystem 在后面才会同步，这里需要提前同步）
+            avoid.positionX = agent.x;
+            avoid.positionY = agent.y;
+
+            // 重置期望速度
+            avoid.preferredVelocityX = 0;
+            avoid.preferredVelocityY = 0;
+
+            // 如果有有效路径，设置期望速度朝向下一路径点
+            if (agent.hasValidPath() && !agent.isPathComplete()) {
+                const waypoint = agent.getNextWaypoint();
+                if (waypoint) {
+                    // 直接计算方向并乘以 maxSpeed
+                    // 不用 setPreferredVelocityTowards 因为它会根据距离降速
+                    const dx = waypoint.x - agent.x;
+                    const dy = waypoint.y - agent.y;
+                    const dist = Math.sqrt(dx * dx + dy * dy);
+                    if (dist > 0.001) {
+                        avoid.preferredVelocityX = (dx / dist) * avoid.maxSpeed;
+                        avoid.preferredVelocityY = (dy / dist) * avoid.maxSpeed;
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ============================================
+// 移动系统
+// 所有坐标都使用网格坐标（与 PathfindingSystem 和 LocalAvoidanceSystem 一致）
+// ============================================
+
+@ECSSystem('Movement', { updateOrder: 60 })
+class MovementSystem extends EntitySystem {
+    constructor() {
+        super(Matcher.all(PathfindingAgentComponent));
+    }
+
+    process(entities) {
+        const dt = Time.deltaTime;
+
+        for (const entity of entities) {
+            const agent = entity.getComponent(PathfindingAgentComponent);
+            const avoid = entity.getComponent(AvoidanceAgentComponent);
+
+            // 等待路径计算完成
+            if (!agent.hasValidPath() || agent.isPathComplete()) {
+                if (avoid) avoid.stop();
+                continue;
+            }
+
+            const waypoint = agent.getNextWaypoint();
+            if (!waypoint) continue;
+
+            // 如果启用避让，使用 ORCA 计算的速度（网格单位/秒）
+            if (params.avoidance && avoid) {
+                agent.x += avoid.velocityX * dt;
+                agent.y += avoid.velocityY * dt;
+            } else {
+                // 直接朝目标移动（网格坐标）
+                const dx = waypoint.x - agent.x;
+                const dy = waypoint.y - agent.y;
+                const dist = Math.sqrt(dx * dx + dy * dy);
+                const moveSpeed = params.speed * dt;  // speed 是网格/秒
+
+                if (dist < 0.1) {
+                    agent.x = waypoint.x;
+                    agent.y = waypoint.y;
+                } else {
+                    agent.x += (dx / dist) * Math.min(moveSpeed, dist);
+                    agent.y += (dy / dist) * Math.min(moveSpeed, dist);
+                }
+            }
+
+            // 检查是否到达路径点（网格距离）
+            const dx = waypoint.x - agent.x;
+            const dy = waypoint.y - agent.y;
+            if (Math.sqrt(dx * dx + dy * dy) < 0.5) {
+                agent.advanceWaypoint();
+            }
+        }
+    }
+}
+
+// ============================================
+// 场景
+// ============================================
+
+class MultiAgentDemoScene extends Scene {
+    mapEntity: any = null;
+    worldEntity: any = null;
+    agents: any[] = [];
+
+    initialize() {
+        this.name = 'MultiAgentDemo';
+
+        // 先创建避让世界实体（必须在 addSystem 之前）
+        if (params.avoidance) {
+            this.worldEntity = this.createEntity('AvoidanceWorld');
+            worldComponent = this.worldEntity.addComponent(new AvoidanceWorldComponent());
+        }
+
+        this.addSystem(new PathfindingSystem());       // order 0: 计算路径
+        if (params.avoidance) {
+            this.addSystem(new PreferredVelocitySystem()); // order 45: 设置期望速度
+            this.addSystem(new LocalAvoidanceSystem());    // order 50: ORCA 计算
+        }
+        this.addSystem(new MovementSystem());          // order 60: 应用速度
+        this.addSystem(new RenderSystem(ctx));         // order 100: 渲染
+    }
+
+    onStart() {
+        this.loadScenario('swap');
+    }
+
+    loadScenario(type: string) {
+        console.log('loadScenario called:', type);
+
+        // 清除（使用正确的 API）
+        if (this.mapEntity) {
+            this.mapEntity.destroy();
+            this.mapEntity = null;
+        }
+        for (const agent of this.agents) {
+            agent.destroy();
+        }
+        this.agents = [];
+
+        // 重置系统的地图引用
+        for (const system of this.systems) {
+            if (system.mapComp) system.mapComp = null;
+        }
+
+        const gridSize = params.gridSize;
+        const gridH = Math.floor(gridSize * HEIGHT / WIDTH);
+
+        // 创建地图
+        this.mapEntity = this.createEntity('Map');
+        const mapComp = this.mapEntity.addComponent(new PathfindingMapComponent());
+        mapComp.width = gridSize;
+        mapComp.height = gridH;
+        mapComp.allowDiagonal = true;
+        mapComp.avoidCorners = true;
+        mapComp.enableSmoothing = false;
+
+        setTimeout(() => {
+            if (!mapComp.map) return;
+
+            // 生成障碍物
+            this.generateObstacles(mapComp);
+
+            const cellW = WIDTH / mapComp.width;
+            const cellH = HEIGHT / mapComp.height;
+            const count = params.agentCount;
+            const colors = [
+                '#00d4ff', '#ff6b6b', '#4ecdc4', '#ffe66d',
+                '#a29bfe', '#fd79a8', '#55efc4', '#ffeaa7',
+                '#74b9ff', '#ff7675', '#00b894', '#e17055'
+            ];
+
+            const scenarios = {
+                swap: () => {
+                    // 左右交换
+                    for (let i = 0; i < count; i++) {
+                        const isLeft = i % 2 === 0;
+                        const row = Math.floor(i / 2);
+                        const startX = isLeft ? 2 : mapComp.width - 3;
+                        const startY = 3 + row * 3;
+                        const endX = isLeft ? mapComp.width - 3 : 2;
+                        const endY = startY;
+                        this.createAgent(startX, startY, endX, endY, colors[i % colors.length], i);
+                    }
+                },
+                gather: () => {
+                    // 从四周聚集到中心
+                    const cx = Math.floor(mapComp.width / 2);
+                    const cy = Math.floor(mapComp.height / 2);
+                    for (let i = 0; i < count; i++) {
+                        const angle = (i / count) * Math.PI * 2;
+                        const radius = Math.min(mapComp.width, mapComp.height) / 2 - 3;
+                        const startX = Math.round(cx + Math.cos(angle) * radius);
+                        const startY = Math.round(cy + Math.sin(angle) * radius);
+                        this.createAgent(startX, startY, cx, cy, colors[i % colors.length], i);
+                    }
+                },
+                scatter: () => {
+                    // 从中心分散到四周
+                    const cx = Math.floor(mapComp.width / 2);
+                    const cy = Math.floor(mapComp.height / 2);
+                    for (let i = 0; i < count; i++) {
+                        const angle = (i / count) * Math.PI * 2;
+                        const radius = Math.min(mapComp.width, mapComp.height) / 2 - 3;
+                        const endX = Math.round(cx + Math.cos(angle) * radius);
+                        const endY = Math.round(cy + Math.sin(angle) * radius);
+                        this.createAgent(cx + (i % 3) - 1, cy + Math.floor(i / 3) - 1, endX, endY, colors[i % colors.length], i);
+                    }
+                },
+                patrol: () => {
+                    // 巡逻路线（定期重新寻路）
+                    for (let i = 0; i < count; i++) {
+                        const startX = 2 + (i % 4) * 7;
+                        const startY = 2 + Math.floor(i / 4) * 7;
+                        const endX = mapComp.width - 3 - (i % 4) * 5;
+                        const endY = mapComp.height - 3 - Math.floor(i / 4) * 5;
+                        this.createAgent(startX, startY, endX, endY, colors[i % colors.length], i);
+                    }
+                }
+            };
+
+            scenarios[type]?.();
+        }, 100);
+    }
+
+    generateObstacles(mapComp) {
+        const w = mapComp.width, h = mapComp.height;
+
+        // 清除旧的 ORCA 障碍物
+        if (worldComponent) {
+            worldComponent.clearObstacles();
+        }
+
+        // 添加一些随机障碍物
+        for (let i = 0; i < 15; i++) {
+            const ox = 5 + Math.floor(Math.random() * (w - 10));
+            const oy = 3 + Math.floor(Math.random() * (h - 6));
+            const ow = 1 + Math.floor(Math.random() * 3);
+            const oh = 1 + Math.floor(Math.random() * 3);
+
+            // 设置寻路地图障碍物
+            mapComp.setRectWalkable(ox, oy, ow, oh, false);
+
+            // 同时添加到 ORCA 避让系统（网格坐标，CW 顺序 = 数学坐标系 CCW）
+            if (worldComponent) {
+                worldComponent.addObstacle({
+                    vertices: [
+                        { x: ox, y: oy },              // 左上
+                        { x: ox + ow, y: oy },         // 右上
+                        { x: ox + ow, y: oy + oh },    // 右下
+                        { x: ox, y: oy + oh }          // 左下
+                    ]
+                });
+            }
+        }
+    }
+
+    createAgent(sx, sy, ex, ey, color, index) {
+        const entity = this.createEntity('Agent' + index);
+
+        // agent.x/y 使用网格坐标（与 PathfindingSystem 和 LocalAvoidanceSystem 一致）
+        const agent = entity.addComponent(new PathfindingAgentComponent());
+        agent.x = sx;
+        agent.y = sy;
+        agent.requestPathTo(ex, ey);
+
+        if (params.avoidance) {
+            const avoid = entity.addComponent(new AvoidanceAgentComponent());
+            // 所有参数都使用网格单位！
+            // LocalAvoidanceSystem 会自动从 agent.x/y 同步位置
+            avoid.radius = 0.4;              // 网格单位（约 0.4 个格子半径）
+            avoid.maxSpeed = params.speed;   // 网格/秒
+            avoid.neighborDist = 3;          // 网格单位（检测 3 格内的邻居）
+            avoid.timeHorizon = 1.5;
+            avoid.autoApplyVelocity = true;  // 自动将 newVelocity 应用到 velocity
+        }
+
+        const visual = entity.addComponent(new AgentVisualComponent());
+        visual.color = color;
+        visual.index = index;
+
+        this.agents.push(entity);
+    }
+}
+
+// ============================================
+// 初始化
+// ============================================
+
+Core.create({ debug: false });
+const demoScene = new MultiAgentDemoScene();
+Core.setScene(demoScene);
+
+// 暴露场景给 DemoPlayground 以支持场景切换
+window.__demoScene = demoScene;
+
+let lastTime = performance.now();
+
+function gameLoop() {
+    const now = performance.now();
+    const dt = Math.min((now - lastTime) / 1000, 0.1);
+    lastTime = now;
+    Core.update(dt);
+    requestAnimationFrame(gameLoop);
+}
+
+gameLoop();`;
+
+这是一个使用 **ECS 架构** 实现的多代理寻路与避让交互式演示，结合了 **A* 寻路** 和 **ORCA 局部避让**。
+
+点击 **Run** 启动模拟，使用工具栏切换场景，关闭 Avoidance 参数观察无避让时的碰撞效果。
+
+<DemoPlayground
+    client:load
+    title="多代理寻路 - ECS 架构"
+    code={multiAgentDemoCode}
+    canvasWidth={580}
+    canvasHeight={380}
+    scenes={multiAgentScenes}
+    params={multiAgentParams}
+/>
+
+<script is:inline src="/esengine/js/esengine.iife.js"></script>
+
+## 场景说明
+
+- **交换位置** - 代理从左右两侧交换位置，测试对向避让
+- **聚集** - 从四周向中心聚集，测试多代理收敛
+- **分散** - 从中心向四周分散，测试扇形避让
+- **巡逻** - 多个代理各自巡逻，测试随机相遇避让
+
+## 相关文档
+
+- [寻路系统 API](/esengine/modules/pathfinding) - A* 寻路文档
+- [ORCA 局部避让](/esengine/modules/pathfinding/local-avoidance) - 多代理避让
+- [快速开始](/esengine/guide/getting-started) - ECS 框架入门

--- a/docs/src/content/docs/examples/orca-avoidance-demo.mdx
+++ b/docs/src/content/docs/examples/orca-avoidance-demo.mdx
@@ -22,11 +22,12 @@ export const orcaParams = [
 export const orcaDemoCode = `// ORCA 局部避让 - ECS 架构演示
 // ============================================
 // 使用工具栏按钮切换场景，使用参数面板调整参数
+// 左键点击画布添加代理，右键点击添加障碍物
 
 const {
     Core, Scene, Component, EntitySystem, Matcher, Time,
     ECSComponent, ECSSystem,
-    AvoidanceAgentComponent, LocalAvoidanceSystem
+    AvoidanceAgentComponent, AvoidanceWorldComponent, LocalAvoidanceSystem
 } = ESEngine;
 
 const WIDTH = 580, HEIGHT = 380;
@@ -36,6 +37,9 @@ const CX = WIDTH / 2, CY = HEIGHT / 2;
 const params = window.__demoParams || {
     agentCount: 40, maxSpeed: 90, radius: 3, neighborDist: 70
 };
+
+// 避让世界组件引用（用于添加障碍物）
+let worldComponent: any = null;
 
 // ============================================
 // 组件定义
@@ -99,6 +103,24 @@ class RenderSystem extends EntitySystem {
         this.ctx.fillStyle = 'rgba(22, 33, 62, 0.3)';
         this.ctx.fillRect(0, 0, WIDTH, HEIGHT);
 
+        // 绘制障碍物
+        this.ctx.fillStyle = '#2d4263';
+        if (worldComponent) {
+            for (const obs of worldComponent.obstacles) {
+                // 障碍物存储为顶点列表，绘制为多边形
+                const v = obs.vertices;
+                if (v.length >= 3) {
+                    this.ctx.beginPath();
+                    this.ctx.moveTo(v[0].x, v[0].y);
+                    for (let i = 1; i < v.length; i++) {
+                        this.ctx.lineTo(v[i].x, v[i].y);
+                    }
+                    this.ctx.closePath();
+                    this.ctx.fill();
+                }
+            }
+        }
+
         // FPS 计算
         this.frameCount++;
         const now = performance.now();
@@ -150,11 +172,14 @@ class RenderSystem extends EntitySystem {
 
         // HUD
         this.ctx.fillStyle = 'rgba(0,0,0,0.6)';
-        this.ctx.fillRect(5, 5, 120, 35);
+        this.ctx.fillRect(5, 5, 150, 58);
         this.ctx.fillStyle = '#00d4ff';
         this.ctx.font = '11px monospace';
         this.ctx.fillText(\`Agents: \${entities.length}\`, 10, 20);
-        this.ctx.fillText(\`FPS: \${this.fps}\`, 10, 32);
+        this.ctx.fillText(\`Obstacles: \${worldComponent?.obstacles.length || 0}\`, 10, 32);
+        this.ctx.fillText(\`FPS: \${this.fps}\`, 10, 44);
+        this.ctx.fillStyle = '#888';
+        this.ctx.fillText('Left:Add Right:Obstacle', 10, 55);
     }
 }
 
@@ -163,20 +188,36 @@ class RenderSystem extends EntitySystem {
 // ============================================
 
 class ORCADemoScene extends Scene {
+    worldEntity: any = null;
+
     initialize() {
         this.name = 'ORCADemo';
+
+        // 先创建避让世界实体（必须在 addSystem 之前，这样 LocalAvoidanceSystem 初始化时能找到）
+        this.worldEntity = this.createEntity('AvoidanceWorld');
+        worldComponent = this.worldEntity.addComponent(new AvoidanceWorldComponent());
+
         this.addSystem(new TargetFollowSystem());
         this.addSystem(new LocalAvoidanceSystem());
         this.addSystem(new MovementSystem());
         this.addSystem(new RenderSystem(ctx));
     }
 
-    onStart() { this.loadScenario('circle'); }
+    onStart() {
+        this.loadScenario('circle');
+    }
 
     loadScenario(type: string) {
-        // 清除现有实体
+        console.log('loadScenario called:', type);
+
+        // 清除现有代理实体
         const result = this.queryAll(AvoidanceAgentComponent);
         this.destroyEntities([...result.entities]);
+
+        // 清除障碍物
+        if (worldComponent) {
+            worldComponent.clearObstacles();
+        }
 
         const count = params.agentCount;
         const configs = {
@@ -247,6 +288,41 @@ Core.create({ debug: false });
 const demoScene = new ORCADemoScene();
 Core.setScene(demoScene);
 
+// 暴露场景给 DemoPlayground
+window.__demoScene = demoScene;
+
+// 鼠标事件处理
+canvas.addEventListener('click', (e: MouseEvent) => {
+    const rect = canvas.getBoundingClientRect();
+    const x = (e.clientX - rect.left) * (canvas.width / rect.width);
+    const y = (e.clientY - rect.top) * (canvas.height / rect.height);
+
+    // 左键添加代理
+    const color = \`hsl(\${Math.random() * 360}, 80%, 60%)\`;
+    demoScene.createAgent(x, y, CX + (Math.random() - 0.5) * 200, CY + (Math.random() - 0.5) * 200, color);
+});
+
+canvas.addEventListener('contextmenu', (e: MouseEvent) => {
+    e.preventDefault();
+    const rect = canvas.getBoundingClientRect();
+    const x = (e.clientX - rect.left) * (canvas.width / rect.width);
+    const y = (e.clientY - rect.top) * (canvas.height / rect.height);
+
+    // 右键添加障碍物到 AvoidanceWorldComponent
+    // ORCA 使用数学坐标系(Y向上)，屏幕坐标系的 CW 顺序 = 数学坐标系的 CCW
+    // 顺序：左上 → 右上 → 右下 → 左下
+    if (worldComponent) {
+        worldComponent.addObstacle({
+            vertices: [
+                { x: x - 15, y: y - 15 },  // 左上
+                { x: x + 15, y: y - 15 },  // 右上
+                { x: x + 15, y: y + 15 },  // 右下
+                { x: x - 15, y: y + 15 }   // 左下
+            ]
+        });
+    }
+});
+
 let lastTime = performance.now();
 let animationId: number;
 
@@ -263,6 +339,10 @@ gameLoop();`;
 这是一个使用 **ECS 架构** 实现的 ORCA (Optimal Reciprocal Collision Avoidance) 局部避让交互式演示。
 
 点击 **Run** 启动模拟，使用工具栏切换场景，调整参数面板中的设置观察不同效果。
+
+**交互操作：**
+- **左键点击** 画布添加新代理
+- **右键点击** 画布放置障碍物
 
 <DemoPlayground
     client:load

--- a/docs/src/content/docs/examples/search-visualization-demo.mdx
+++ b/docs/src/content/docs/examples/search-visualization-demo.mdx
@@ -1,0 +1,543 @@
+---
+title: "A* 搜索可视化"
+description: "可视化 A* 算法的搜索过程，理解启发式搜索原理"
+---
+
+import DemoPlayground from '../../../components/DemoPlayground.vue';
+
+export const vizScenes = [
+    { id: 'simple', label: '○', name: '简单路径' },
+    { id: 'obstacle', label: '⬛', name: '绕过障碍' },
+    { id: 'maze', label: '⬜', name: '迷宫' },
+    { id: 'deadend', label: '✕', name: '死路测试' }
+];
+
+export const vizParams = [
+    { id: 'gridSize', label: 'Grid', desc: '网格大小', value: 25, min: 15, max: 40, step: 5 },
+    { id: 'speed', label: 'Speed', desc: '搜索速度（步/帧）', value: 3, min: 1, max: 20, step: 1 },
+    { id: 'diagonal', label: 'Diagonal', desc: '对角移动（0=否，1=是）', value: 1, min: 0, max: 1, step: 1 }
+];
+
+export const vizDemoCode = `// A* 搜索可视化 - 理解启发式搜索
+// ============================================
+// 观察 Open Set（待探索）和 Closed Set（已探索）的变化
+
+const { createGridMap } = ESEngine;
+
+const WIDTH = 580, HEIGHT = 380;
+
+const params = window.__demoParams || {
+    gridSize: 25, speed: 3, diagonal: 1
+};
+
+// 本地实现启发式函数
+function manhattanDist(a, b) {
+    return Math.abs(a.x - b.x) + Math.abs(a.y - b.y);
+}
+
+function octileDist(a, b) {
+    const dx = Math.abs(a.x - b.x);
+    const dy = Math.abs(a.y - b.y);
+    return dx + dy + (1.414 - 2) * Math.min(dx, dy);
+}
+
+let gridMap = null;
+let gridWidth = 25, gridHeight = 16;
+let startPos = { x: 2, y: 2 };
+let endPos = { x: 0, y: 0 };
+
+// 搜索状态
+let searchState = {
+    running: false,
+    completed: false,
+    found: false,
+    openSet: new Map(),      // key -> { x, y, g, h, f, parent }
+    closedSet: new Set(),    // key strings
+    path: [],
+    currentBest: null,
+    nodesSearched: 0,
+    startTime: 0,
+    endTime: 0
+};
+
+// ============================================
+// 可视化 A* 实现
+// ============================================
+
+function nodeKey(x, y) {
+    return x + ',' + y;
+}
+
+function initSearch() {
+    const h = params.diagonal === 1
+        ? octileDist(startPos, endPos)
+        : manhattanDist(startPos, endPos);
+
+    searchState = {
+        running: true,
+        completed: false,
+        found: false,
+        openSet: new Map(),
+        closedSet: new Set(),
+        path: [],
+        currentBest: null,
+        nodesSearched: 0,
+        startTime: performance.now(),
+        endTime: 0
+    };
+
+    searchState.openSet.set(nodeKey(startPos.x, startPos.y), {
+        x: startPos.x,
+        y: startPos.y,
+        g: 0,
+        h: h,
+        f: h,
+        parent: null
+    });
+}
+
+function stepSearch() {
+    if (!searchState.running || searchState.completed) return;
+
+    const { openSet, closedSet } = searchState;
+
+    if (openSet.size === 0) {
+        searchState.completed = true;
+        searchState.running = false;
+        searchState.found = false;
+        searchState.endTime = performance.now();
+        return;
+    }
+
+    // 找到 f 值最小的节点
+    let bestKey = null;
+    let bestNode = null;
+    for (const [key, node] of openSet) {
+        if (!bestNode || node.f < bestNode.f || (node.f === bestNode.f && node.h < bestNode.h)) {
+            bestKey = key;
+            bestNode = node;
+        }
+    }
+
+    searchState.currentBest = bestNode;
+    searchState.nodesSearched++;
+
+    // 检查是否到达终点
+    if (bestNode.x === endPos.x && bestNode.y === endPos.y) {
+        searchState.completed = true;
+        searchState.running = false;
+        searchState.found = true;
+        searchState.endTime = performance.now();
+
+        // 回溯路径
+        const path = [];
+        let current = bestNode;
+        while (current) {
+            path.unshift({ x: current.x, y: current.y });
+            current = current.parent;
+        }
+        searchState.path = path;
+        return;
+    }
+
+    // 从 open set 移到 closed set
+    openSet.delete(bestKey);
+    closedSet.add(bestKey);
+
+    // 展开邻居
+    const neighbors = getNeighbors(bestNode.x, bestNode.y);
+    for (const neighbor of neighbors) {
+        const key = nodeKey(neighbor.x, neighbor.y);
+
+        if (closedSet.has(key)) continue;
+        if (!gridMap.isWalkable(neighbor.x, neighbor.y)) continue;
+
+        const tentativeG = bestNode.g + neighbor.cost;
+
+        const existing = openSet.get(key);
+        if (existing && tentativeG >= existing.g) continue;
+
+        const h = params.diagonal === 1
+            ? octileDist(neighbor, endPos)
+            : manhattanDist(neighbor, endPos);
+
+        const newNode = {
+            x: neighbor.x,
+            y: neighbor.y,
+            g: tentativeG,
+            h: h,
+            f: tentativeG + h,
+            parent: bestNode
+        };
+
+        openSet.set(key, newNode);
+    }
+}
+
+function getNeighbors(x, y) {
+    const neighbors = [];
+    const dirs4 = [[0, -1], [1, 0], [0, 1], [-1, 0]];
+    const dirs8 = [[0, -1], [1, -1], [1, 0], [1, 1], [0, 1], [-1, 1], [-1, 0], [-1, -1]];
+    const dirs = params.diagonal === 1 ? dirs8 : dirs4;
+
+    for (let i = 0; i < dirs.length; i++) {
+        const [dx, dy] = dirs[i];
+        const nx = x + dx, ny = y + dy;
+        if (nx >= 0 && nx < gridWidth && ny >= 0 && ny < gridHeight) {
+            const cost = (dx !== 0 && dy !== 0) ? 1.414 : 1;
+            neighbors.push({ x: nx, y: ny, cost });
+        }
+    }
+    return neighbors;
+}
+
+// ============================================
+// 渲染
+// ============================================
+
+function render(ctx) {
+    if (!gridMap) return;
+
+    const cellW = WIDTH / gridWidth;
+    const cellH = HEIGHT / gridHeight;
+
+    // 清屏
+    ctx.fillStyle = '#16213e';
+    ctx.fillRect(0, 0, WIDTH, HEIGHT);
+
+    // 绘制障碍物（先画，作为背景）
+    ctx.fillStyle = '#2d4263';
+    for (let y = 0; y < gridHeight; y++) {
+        for (let x = 0; x < gridWidth; x++) {
+            if (!gridMap.isWalkable(x, y)) {
+                ctx.fillRect(x * cellW, y * cellH, cellW - 1, cellH - 1);
+            }
+        }
+    }
+
+    // 绘制 Closed Set（已探索）
+    ctx.fillStyle = 'rgba(100, 100, 150, 0.6)';
+    for (const key of searchState.closedSet) {
+        const [x, y] = key.split(',').map(Number);
+        ctx.fillRect(x * cellW + 1, y * cellH + 1, cellW - 2, cellH - 2);
+    }
+
+    // 绘制 Open Set（待探索/边界）
+    for (const [key, node] of searchState.openSet) {
+        // 用 f 值决定颜色深浅
+        const intensity = Math.max(0.3, 1 - node.f / 100);
+        ctx.fillStyle = \`rgba(0, 200, 255, \${intensity * 0.7})\`;
+        ctx.fillRect(node.x * cellW + 1, node.y * cellH + 1, cellW - 2, cellH - 2);
+    }
+
+    // 绘制路径
+    if (searchState.path.length > 0) {
+        ctx.strokeStyle = '#4ecdc4';
+        ctx.lineWidth = 3;
+        ctx.beginPath();
+        ctx.moveTo(searchState.path[0].x * cellW + cellW/2, searchState.path[0].y * cellH + cellH/2);
+        for (let i = 1; i < searchState.path.length; i++) {
+            ctx.lineTo(searchState.path[i].x * cellW + cellW/2, searchState.path[i].y * cellH + cellH/2);
+        }
+        ctx.stroke();
+    }
+
+    // 当前最佳节点到起点的路径
+    if (searchState.currentBest && !searchState.completed) {
+        ctx.strokeStyle = 'rgba(255, 230, 109, 0.6)';
+        ctx.lineWidth = 2;
+        ctx.beginPath();
+        let node = searchState.currentBest;
+        ctx.moveTo(node.x * cellW + cellW/2, node.y * cellH + cellH/2);
+        while (node.parent) {
+            node = node.parent;
+            ctx.lineTo(node.x * cellW + cellW/2, node.y * cellH + cellH/2);
+        }
+        ctx.stroke();
+    }
+
+    // 绘制网格线
+    ctx.strokeStyle = 'rgba(255,255,255,0.15)';
+    ctx.lineWidth = 1;
+    for (let x = 0; x <= gridWidth; x++) {
+        ctx.beginPath();
+        ctx.moveTo(x * cellW, 0);
+        ctx.lineTo(x * cellW, HEIGHT);
+        ctx.stroke();
+    }
+    for (let y = 0; y <= gridHeight; y++) {
+        ctx.beginPath();
+        ctx.moveTo(0, y * cellH);
+        ctx.lineTo(WIDTH, y * cellH);
+        ctx.stroke();
+    }
+
+    // 绘制起点
+    ctx.fillStyle = '#00d4ff';
+    ctx.beginPath();
+    ctx.arc(startPos.x * cellW + cellW/2, startPos.y * cellH + cellH/2, Math.min(cellW, cellH) * 0.35, 0, Math.PI * 2);
+    ctx.fill();
+
+    // 绘制终点
+    ctx.fillStyle = '#ff6b6b';
+    ctx.beginPath();
+    ctx.arc(endPos.x * cellW + cellW/2, endPos.y * cellH + cellH/2, Math.min(cellW, cellH) * 0.35, 0, Math.PI * 2);
+    ctx.fill();
+
+    // HUD
+    const panelX = 5, panelY = 5;
+    ctx.fillStyle = 'rgba(0,0,0,0.8)';
+    ctx.fillRect(panelX, panelY, 175, 100);
+
+    ctx.font = 'bold 11px monospace';
+    ctx.fillStyle = '#fff';
+    ctx.fillText('A* Search Visualization', panelX + 5, panelY + 15);
+
+    ctx.font = '10px monospace';
+    ctx.fillStyle = '#00d4ff';
+    ctx.fillText(\`Open Set:   \${searchState.openSet.size}\`, panelX + 5, panelY + 32);
+    ctx.fillStyle = 'rgba(150, 150, 200, 1)';
+    ctx.fillText(\`Closed Set: \${searchState.closedSet.size}\`, panelX + 5, panelY + 45);
+    ctx.fillStyle = '#ffe66d';
+    ctx.fillText(\`Nodes:      \${searchState.nodesSearched}\`, panelX + 5, panelY + 58);
+
+    if (searchState.completed) {
+        const time = (searchState.endTime - searchState.startTime).toFixed(2);
+        ctx.fillStyle = searchState.found ? '#4ecdc4' : '#ff6b6b';
+        ctx.fillText(searchState.found ? \`Path found! \${searchState.path.length} nodes\` : 'No path found!', panelX + 5, panelY + 73);
+        ctx.fillStyle = '#888';
+        ctx.fillText(\`Time: \${time}ms\`, panelX + 5, panelY + 86);
+    } else if (searchState.running) {
+        ctx.fillStyle = '#4ecdc4';
+        ctx.fillText('Searching...', panelX + 5, panelY + 73);
+    } else {
+        ctx.fillStyle = '#888';
+        ctx.fillText('Click to set start/end', panelX + 5, panelY + 73);
+    }
+
+    // 图例
+    const legendX = WIDTH - 120, legendY = 5;
+    ctx.fillStyle = 'rgba(0,0,0,0.8)';
+    ctx.fillRect(legendX, legendY, 115, 70);
+    ctx.font = '9px monospace';
+
+    ctx.fillStyle = 'rgba(0, 200, 255, 0.6)';
+    ctx.fillRect(legendX + 5, legendY + 8, 12, 12);
+    ctx.fillStyle = '#fff';
+    ctx.fillText('Open (frontier)', legendX + 22, legendY + 18);
+
+    ctx.fillStyle = 'rgba(100, 100, 150, 0.5)';
+    ctx.fillRect(legendX + 5, legendY + 25, 12, 12);
+    ctx.fillStyle = '#fff';
+    ctx.fillText('Closed (explored)', legendX + 22, legendY + 35);
+
+    ctx.fillStyle = '#ffe66d';
+    ctx.fillRect(legendX + 5, legendY + 42, 12, 12);
+    ctx.fillStyle = '#fff';
+    ctx.fillText('Current path', legendX + 22, legendY + 52);
+
+    ctx.fillStyle = '#4ecdc4';
+    ctx.fillRect(legendX + 5, legendY + 59, 12, 12);
+    ctx.fillStyle = '#fff';
+    ctx.fillText('Final path', legendX + 22, legendY + 69);
+}
+
+// ============================================
+// 地图生成
+// ============================================
+
+function generateMap(type) {
+    gridWidth = params.gridSize;
+    gridHeight = Math.floor(gridWidth * HEIGHT / WIDTH);
+
+    gridMap = createGridMap(gridWidth, gridHeight);
+
+    // 重置搜索状态
+    searchState = {
+        running: false,
+        completed: false,
+        found: false,
+        openSet: new Map(),
+        closedSet: new Set(),
+        path: [],
+        currentBest: null,
+        nodesSearched: 0,
+        startTime: 0,
+        endTime: 0
+    };
+
+    const w = gridWidth, h = gridHeight;
+
+    const generators = {
+        simple: () => {
+            // 空地图，简单路径
+            startPos = { x: 2, y: Math.floor(h / 2) };
+            endPos = { x: w - 3, y: Math.floor(h / 2) };
+        },
+        obstacle: () => {
+            // 中间有障碍物
+            const midX = Math.floor(w / 2);
+            for (let y = 3; y < h - 3; y++) {
+                gridMap.setWalkable(midX, y, false);
+            }
+            startPos = { x: 3, y: Math.floor(h / 2) };
+            endPos = { x: w - 4, y: Math.floor(h / 2) };
+        },
+        maze: () => {
+            // 简单迷宫
+            for (let y = 0; y < h; y++) {
+                for (let x = 0; x < w; x++) {
+                    gridMap.setWalkable(x, y, false);
+                }
+            }
+            const carve = (x, y) => {
+                gridMap.setWalkable(x, y, true);
+                const dirs = [[0,-2],[0,2],[-2,0],[2,0]].sort(() => Math.random() - 0.5);
+                for (const [dx, dy] of dirs) {
+                    const nx = x + dx, ny = y + dy;
+                    if (nx > 0 && nx < w-1 && ny > 0 && ny < h-1 && !gridMap.isWalkable(nx, ny)) {
+                        gridMap.setWalkable(x + dx/2, y + dy/2, true);
+                        carve(nx, ny);
+                    }
+                }
+            };
+            carve(1, 1);
+            startPos = { x: 1, y: 1 };
+            endPos = findWalkable(w - 2, h - 2);
+        },
+        deadend: () => {
+            // 死路测试（终点被包围）
+            const cx = Math.floor(w / 2);
+            const cy = Math.floor(h / 2);
+            // 围墙
+            for (let x = cx - 3; x <= cx + 3; x++) {
+                gridMap.setWalkable(x, cy - 3, false);
+                gridMap.setWalkable(x, cy + 3, false);
+            }
+            for (let y = cy - 3; y <= cy + 3; y++) {
+                gridMap.setWalkable(cx - 3, y, false);
+                gridMap.setWalkable(cx + 3, y, false);
+            }
+            startPos = { x: 2, y: 2 };
+            endPos = { x: cx, y: cy };
+        }
+    };
+
+    generators[type]?.();
+}
+
+function findWalkable(px, py) {
+    if (gridMap.isWalkable(px, py)) return { x: px, y: py };
+    for (let r = 1; r < 20; r++) {
+        for (let dx = -r; dx <= r; dx++) {
+            for (let dy = -r; dy <= r; dy++) {
+                const x = px + dx, y = py + dy;
+                if (x >= 0 && x < gridWidth && y >= 0 && y < gridHeight) {
+                    if (gridMap.isWalkable(x, y)) return { x, y };
+                }
+            }
+        }
+    }
+    return { x: 1, y: 1 };
+}
+
+// ============================================
+// 初始化
+// ============================================
+
+generateMap('simple');
+initSearch();  // 自动开始搜索
+
+// 点击设置起点/终点并开始搜索
+let clickMode = 'start';
+canvas.addEventListener('click', (e) => {
+    const rect = canvas.getBoundingClientRect();
+    const mx = (e.clientX - rect.left) * (canvas.width / rect.width);
+    const my = (e.clientY - rect.top) * (canvas.height / rect.height);
+    const cellW = WIDTH / gridWidth;
+    const cellH = HEIGHT / gridHeight;
+    const gx = Math.floor(mx / cellW);
+    const gy = Math.floor(my / cellH);
+
+    if (gx >= 0 && gx < gridWidth && gy >= 0 && gy < gridHeight && gridMap.isWalkable(gx, gy)) {
+        if (clickMode === 'start') {
+            startPos = { x: gx, y: gy };
+            clickMode = 'end';
+        } else {
+            endPos = { x: gx, y: gy };
+            clickMode = 'start';
+            // 开始搜索
+            initSearch();
+        }
+    }
+});
+
+// 场景切换
+window.__demoScene = {
+    loadScenario: (type) => {
+        generateMap(type);
+        initSearch();
+    }
+};
+
+// 游戏循环
+function gameLoop() {
+    // 每帧执行多步搜索
+    if (searchState.running) {
+        for (let i = 0; i < params.speed; i++) {
+            stepSearch();
+        }
+    }
+
+    render(ctx);
+    requestAnimationFrame(gameLoop);
+}
+
+gameLoop();`;
+
+这是一个 **A* 搜索可视化演示**，帮助理解启发式搜索算法的工作原理。
+
+点击 **Run** 开始，然后点击地图设置起点和终点。
+
+**颜色说明：**
+- 🟦 **蓝色** - Open Set（待探索的边界节点）
+- 🟫 **灰紫色** - Closed Set（已探索的节点）
+- 🟨 **黄色线** - 当前最佳路径
+- 🟩 **青色线** - 最终路径
+
+<DemoPlayground
+    client:load
+    title="A* 搜索可视化"
+    code={vizDemoCode}
+    canvasWidth={580}
+    canvasHeight={380}
+    scenes={vizScenes}
+    params={vizParams}
+/>
+
+<script is:inline src="/esengine/js/esengine.iife.js"></script>
+
+## A* 算法原理
+
+A* 算法通过维护两个集合来搜索最短路径：
+
+| 集合 | 作用 |
+|------|------|
+| **Open Set** | 已发现但未探索的节点（搜索边界） |
+| **Closed Set** | 已完全探索的节点 |
+
+每次迭代选择 Open Set 中 **f(n) = g(n) + h(n)** 最小的节点展开：
+- **g(n)** - 从起点到当前节点的实际代价
+- **h(n)** - 从当前节点到终点的启发式估计
+
+## 场景说明
+
+- **简单路径** - 无障碍直线，观察算法如何"直奔"目标
+- **绕过障碍** - 看算法如何在遇到障碍时调整方向
+- **迷宫** - 复杂环境下的搜索行为
+- **死路测试** - 终点被包围，观察算法探索整个可达区域
+
+## 相关文档
+
+- [算法对比演示](/esengine/examples/algorithm-comparison-demo) - 比较不同算法
+- [寻路系统 API](/esengine/modules/pathfinding) - 完整文档

--- a/docs/src/content/docs/modules/pathfinding/index.md
+++ b/docs/src/content/docs/modules/pathfinding/index.md
@@ -131,6 +131,14 @@ interface IPathfindingOptions {
 | 精度 | 网格对齐 | 连续坐标 |
 | 动态修改 | 容易 | 需要重建 |
 
+## 在线演示
+
+体验寻路系统的交互式演示：
+
+- [A* 寻路演示](/esengine/examples/astar-pathfinding-demo) - 网格寻路可视化
+- [多代理寻路演示](/esengine/examples/multi-agent-pathfinding-demo) - A* + ORCA 避让结合
+- [ORCA 局部避让演示](/esengine/examples/orca-avoidance-demo) - 多代理碰撞避让
+
 ## 文档导航
 
 - [网格地图 API](./grid-map) - 网格操作和 A* 寻路

--- a/packages/devtools/demo-bundle/package.json
+++ b/packages/devtools/demo-bundle/package.json
@@ -1,0 +1,26 @@
+{
+    "name": "@esengine/demo-bundle",
+    "version": "1.0.0",
+    "description": "Browser bundle for ESEngine demos",
+    "type": "module",
+    "main": "./dist/esengine.iife.js",
+    "scripts": {
+        "build": "rollup -c",
+        "build:watch": "rollup -c -w",
+        "clean": "rimraf dist"
+    },
+    "dependencies": {
+        "@esengine/ecs-framework": "workspace:*",
+        "@esengine/ecs-framework-math": "workspace:*",
+        "@esengine/pathfinding": "workspace:*"
+    },
+    "devDependencies": {
+        "@rollup/plugin-commonjs": "^25.0.0",
+        "@rollup/plugin-node-resolve": "^15.0.0",
+        "@rollup/plugin-typescript": "^11.0.0",
+        "rollup": "^4.0.0",
+        "rollup-plugin-dts": "^6.0.0",
+        "typescript": "^5.8.0"
+    },
+    "private": true
+}

--- a/packages/devtools/demo-bundle/rollup.config.js
+++ b/packages/devtools/demo-bundle/rollup.config.js
@@ -1,0 +1,24 @@
+import resolve from '@rollup/plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs';
+import typescript from '@rollup/plugin-typescript';
+
+export default {
+    input: 'src/index.ts',
+    output: {
+        file: 'dist/esengine.iife.js',
+        format: 'iife',
+        name: 'ESEngine',
+        sourcemap: true
+    },
+    plugins: [
+        resolve({
+            browser: true,
+            preferBuiltins: false
+        }),
+        commonjs(),
+        typescript({
+            tsconfig: './tsconfig.json',
+            declaration: false
+        })
+    ]
+};

--- a/packages/devtools/demo-bundle/src/index.ts
+++ b/packages/devtools/demo-bundle/src/index.ts
@@ -1,0 +1,168 @@
+/**
+ * ESEngine Demo Bundle
+ *
+ * 浏览器可用的 ESEngine 核心库 bundle
+ * 包含 ECS 框架、数学库、寻路和避让系统
+ */
+
+// =============================================================================
+// ECS Core - 核心 ECS 框架
+// =============================================================================
+
+export {
+    // Core 单例
+    Core,
+    ServiceContainer,
+    ServiceLifetime,
+
+    // ECS 核心类
+    Entity,
+    Component,
+    Scene,
+    World,
+    SceneManager,
+    WorldManager,
+
+    // 系统类
+    EntitySystem,
+    ProcessingSystem,
+    PassiveSystem,
+    IntervalSystem,
+
+    // 查询和匹配
+    Matcher,
+
+    // 时间
+    Time,
+
+    // 装饰器
+    ECSComponent,
+    ECSSystem,
+
+    // 事件
+    Emitter,
+
+    // 日志
+    Logger,
+    createLogger,
+    LogLevel,
+
+    // 工具
+    GlobalManager,
+    TimerManager,
+    Timer
+} from '@esengine/ecs-framework';
+
+// =============================================================================
+// Math - 数学库
+// =============================================================================
+
+export {
+    // 向量
+    Vector2,
+    Vector3,
+
+    // 矩阵
+    Matrix3,
+
+    // 几何形状
+    Rectangle,
+    Circle,
+    Polygon,
+
+    // 定点数（帧同步）
+    Fixed32,
+    FixedVector2,
+    FixedMath,
+
+    // 工具
+    MathUtils,
+    Color
+} from '@esengine/ecs-framework-math';
+
+export type {
+    IVector2,
+    IVector3,
+    RGBA,
+    HSL
+} from '@esengine/ecs-framework-math';
+
+// =============================================================================
+// Pathfinding - 寻路
+// =============================================================================
+
+export {
+    // 网格地图
+    GridMap,
+    createGridMap,
+
+    // 寻路器
+    AStarPathfinder,
+    createAStarPathfinder,
+    GridPathfinder,
+    JPSPathfinder,
+    HPAPathfinder,
+
+    // 增量寻路
+    IncrementalAStarPathfinder,
+
+    // 导航网格
+    NavMesh,
+    createNavMesh,
+
+    // 路径平滑
+    createLineOfSightSmoother,
+    createCatmullRomSmoother,
+    createCombinedSmoother,
+
+    // 启发式函数
+    manhattanDistance,
+    euclideanDistance,
+    chebyshevDistance,
+    octileDistance
+} from '@esengine/pathfinding';
+
+// =============================================================================
+// Avoidance - ORCA 局部避让
+// =============================================================================
+
+export {
+    // ORCA 核心
+    ORCASolver,
+    createORCASolver,
+
+    // 空间索引
+    KDTree,
+    createKDTree,
+
+    // 线性规划
+    solveORCALinearProgram,
+
+    // 默认配置
+    DEFAULT_ORCA_CONFIG,
+    DEFAULT_AGENT_PARAMS
+} from '@esengine/pathfinding/avoidance';
+
+export type {
+    IAvoidanceAgent,
+    IObstacle,
+    IORCASolverConfig,
+    IORCALine,
+    INeighborResult
+} from '@esengine/pathfinding/avoidance';
+
+// =============================================================================
+// Pathfinding ECS - 寻路 ECS 组件和系统
+// =============================================================================
+
+export {
+    // 寻路组件
+    PathfindingAgentComponent,
+    PathfindingMapComponent,
+    PathfindingSystem,
+
+    // 避让组件
+    AvoidanceAgentComponent,
+    AvoidanceWorldComponent,
+    LocalAvoidanceSystem
+} from '@esengine/pathfinding/ecs';

--- a/packages/devtools/demo-bundle/tsconfig.json
+++ b/packages/devtools/demo-bundle/tsconfig.json
@@ -1,0 +1,14 @@
+{
+    "compilerOptions": {
+        "target": "ES2020",
+        "module": "ESNext",
+        "moduleResolution": "bundler",
+        "esModuleInterop": true,
+        "strict": true,
+        "skipLibCheck": true,
+        "declaration": false,
+        "outDir": "./dist",
+        "rootDir": "./src"
+    },
+    "include": ["src/**/*"]
+}

--- a/packages/framework/pathfinding/__tests__/core/HPADebug.test.ts
+++ b/packages/framework/pathfinding/__tests__/core/HPADebug.test.ts
@@ -1,0 +1,187 @@
+/**
+ * HPA* 调试测试
+ */
+import { describe, it, expect } from 'vitest';
+import { HPAPathfinder } from '../../src/core/HPAPathfinder';
+import { AStarPathfinder } from '../../src/core/AStarPathfinder';
+import { GridMap } from '../../src/grid/GridMap';
+
+describe('HPA* Debug', () => {
+    it('should produce straight path on open map', () => {
+        // 创建一个无障碍的 200x200 地图
+        const map = new GridMap(200, 200, { allowDiagonal: true });
+
+        console.log('\n=== Open Map Path Test (should be nearly straight) ===');
+
+        // A* 基准 - 直线路径
+        const astar = new AStarPathfinder(map);
+        const astarResult = astar.findPath(10, 100, 190, 100, { maxNodes: 100000 });
+        console.log(`A* path length: ${astarResult.path.length}, cost: ${astarResult.cost.toFixed(2)}`);
+
+        // HPA* - 应该也接近直线
+        const hpa = new HPAPathfinder(map, {
+            clusterSize: 40,
+            maxEntranceWidth: 16,  // 默认值
+            entranceStrategy: 'end'
+        });
+        hpa.preprocess();
+        const stats = hpa.getStats();
+        console.log(`Clusters: ${stats.clusters}, Entrances: ${stats.entrances}, Nodes: ${stats.abstractNodes}`);
+
+        const hpaResult = hpa.findPath(10, 100, 190, 100, { maxNodes: 100000 });
+        console.log(`HPA* path length: ${hpaResult.path.length}, cost: ${hpaResult.cost.toFixed(2)}`);
+
+        // 打印路径的关键点
+        console.log('\nHPA* path sample points (should stay near y=100):');
+        for (let i = 0; i < hpaResult.path.length; i += Math.max(1, Math.floor(hpaResult.path.length / 10))) {
+            const p = hpaResult.path[i];
+            const yDeviation = Math.abs(p.y - 100);
+            console.log(`  [${i}]: (${p.x}, ${p.y}) - y deviation: ${yDeviation}`);
+        }
+
+        const ratio = hpaResult.path.length / astarResult.path.length;
+        console.log(`\nHPA*/A* ratio: ${ratio.toFixed(3)}`);
+
+        // 检查 y 偏差 - 开放地图上应该几乎是直线
+        let maxYDeviation = 0;
+        for (const p of hpaResult.path) {
+            maxYDeviation = Math.max(maxYDeviation, Math.abs(p.y - 100));
+        }
+        console.log(`Max Y deviation from straight line: ${maxYDeviation}`);
+
+        expect(astarResult.found).toBe(true);
+        expect(hpaResult.found).toBe(true);
+        // 路径不应该偏离太多
+        expect(maxYDeviation).toBeLessThan(50);  // 允许一些偏差，因为要经过入口节点
+    });
+
+    it('should find path on simple 1000x1000 map', () => {
+        const map = new GridMap(1000, 1000, { allowDiagonal: true });
+
+        // 无障碍
+        const hpa = new HPAPathfinder(map, { clusterSize: 100 });
+
+        console.log('\n--- Preprocessing ---');
+        const t0 = performance.now();
+        hpa.preprocess();
+        console.log(`Prep time: ${(performance.now() - t0).toFixed(2)}ms`);
+
+        const stats = hpa.getStats();
+        console.log(`Clusters: ${stats.clusters}`);
+        console.log(`Abstract nodes: ${stats.abstractNodes}`);
+        console.log(`Cache size: ${stats.cacheSize}`);
+
+        console.log('\n--- A* ---');
+        const astar = new AStarPathfinder(map);
+        const t1 = performance.now();
+        const astarResult = astar.findPath(10, 10, 990, 990, { maxNodes: 2000000 });
+        console.log(`A* time: ${(performance.now() - t1).toFixed(2)}ms`);
+        console.log(`A* found: ${astarResult.found}, path: ${astarResult.path.length}`);
+
+        console.log('\n--- HPA* ---');
+        const t2 = performance.now();
+        const hpaResult = hpa.findPath(10, 10, 990, 990, { maxNodes: 2000000 });
+        console.log(`HPA* time: ${(performance.now() - t2).toFixed(2)}ms`);
+        console.log(`HPA* found: ${hpaResult.found}, path: ${hpaResult.path.length}`);
+
+        expect(astarResult.found).toBe(true);
+        expect(hpaResult.found).toBe(true);
+
+        // 路径应该差不多
+        if (hpaResult.found && astarResult.found) {
+            const ratio = hpaResult.path.length / astarResult.path.length;
+            console.log(`Path ratio: ${ratio.toFixed(2)}`);
+            expect(ratio).toBeGreaterThan(0.8);
+            expect(ratio).toBeLessThan(1.5);
+        }
+    });
+
+    it('should produce diagonal path similar to A* (demo scenario)', () => {
+        // 模拟 demo 场景：100x65 地图，15% 障碍物，对角线路径
+        const map = new GridMap(100, 65, { allowDiagonal: true });
+
+        // 随机障碍（固定种子）
+        const seed = 12345;
+        let rng = seed;
+        const random = () => {
+            rng = (rng * 1103515245 + 12345) & 0x7fffffff;
+            return rng / 0x7fffffff;
+        };
+
+        const obstacleRate = 0.15;
+        for (let y = 0; y < 65; y++) {
+            for (let x = 0; x < 100; x++) {
+                if (random() < obstacleRate) {
+                    map.setWalkable(x, y, false);
+                }
+            }
+        }
+
+        // 清除起点终点区域
+        const clearRadius = 3;
+        const startPos = { x: 5, y: 5 };
+        const endPos = { x: 94, y: 59 };
+
+        for (let dy = -clearRadius; dy <= clearRadius; dy++) {
+            for (let dx = -clearRadius; dx <= clearRadius; dx++) {
+                const x1 = startPos.x + dx, y1 = startPos.y + dy;
+                const x2 = endPos.x + dx, y2 = endPos.y + dy;
+                if (x1 >= 0 && x1 < 100 && y1 >= 0 && y1 < 65) {
+                    map.setWalkable(x1, y1, true);
+                }
+                if (x2 >= 0 && x2 < 100 && y2 >= 0 && y2 < 65) {
+                    map.setWalkable(x2, y2, true);
+                }
+            }
+        }
+
+        console.log('\n=== Demo Scenario Test (diagonal with obstacles) ===');
+
+        // A* 基准
+        const astar = new AStarPathfinder(map);
+        const astarResult = astar.findPath(startPos.x, startPos.y, endPos.x, endPos.y, { maxNodes: 100000 });
+        console.log(`A* path length: ${astarResult.path.length}, cost: ${astarResult.cost.toFixed(2)}`);
+
+        // HPA* - 使用 demo 相同的配置
+        const hpa = new HPAPathfinder(map, {
+            clusterSize: 20,  // demo 默认值
+            maxEntranceWidth: 16,
+            entranceStrategy: 'end'
+        });
+        hpa.preprocess();
+        const stats = hpa.getStats();
+        console.log(`Clusters: ${stats.clusters}, Entrances: ${stats.entrances}, Nodes: ${stats.abstractNodes}`);
+
+        const hpaResult = hpa.findPath(startPos.x, startPos.y, endPos.x, endPos.y, { maxNodes: 100000 });
+        console.log(`HPA* path length: ${hpaResult.path.length}, cost: ${hpaResult.cost.toFixed(2)}`);
+
+        // 打印路径差异
+        console.log('\nPath comparison:');
+        console.log(`  A* start: (${astarResult.path[0]?.x}, ${astarResult.path[0]?.y})`);
+        console.log(`  A* end: (${astarResult.path[astarResult.path.length - 1]?.x}, ${astarResult.path[astarResult.path.length - 1]?.y})`);
+        console.log(`  HPA* start: (${hpaResult.path[0]?.x}, ${hpaResult.path[0]?.y})`);
+        console.log(`  HPA* end: (${hpaResult.path[hpaResult.path.length - 1]?.x}, ${hpaResult.path[hpaResult.path.length - 1]?.y})`);
+
+        // 对比路径偏差
+        let maxDeviation = 0;
+
+        console.log('\nHPA* path sample points:');
+        for (let i = 0; i < hpaResult.path.length; i += Math.max(1, Math.floor(hpaResult.path.length / 10))) {
+            const p = hpaResult.path[i];
+            // 计算到理想对角线的偏差
+            const idealY = startPos.y + (endPos.y - startPos.y) * (p.x - startPos.x) / (endPos.x - startPos.x);
+            const deviation = Math.abs(p.y - idealY);
+            maxDeviation = Math.max(maxDeviation, deviation);
+            console.log(`  [${i}]: (${p.x}, ${p.y}) - ideal y: ${idealY.toFixed(1)}, deviation: ${deviation.toFixed(1)}`);
+        }
+
+        const ratio = hpaResult.path.length / astarResult.path.length;
+        console.log(`\nHPA*/A* path length ratio: ${ratio.toFixed(3)}`);
+        console.log(`Max deviation from ideal diagonal: ${maxDeviation.toFixed(1)}`);
+
+        expect(astarResult.found).toBe(true);
+        expect(hpaResult.found).toBe(true);
+        // 路径长度不应该偏差太多
+        expect(ratio).toBeLessThan(1.5);
+    });
+});

--- a/packages/framework/pathfinding/__tests__/core/HPAPathfinder.test.ts
+++ b/packages/framework/pathfinding/__tests__/core/HPAPathfinder.test.ts
@@ -258,8 +258,8 @@ describe('HPAPathfinder', () => {
 
     describe('Configuration', () => {
         it('should use default config values', () => {
-            expect(DEFAULT_HPA_CONFIG.clusterSize).toBe(10);
-            expect(DEFAULT_HPA_CONFIG.maxEntranceWidth).toBe(6);
+            expect(DEFAULT_HPA_CONFIG.clusterSize).toBe(64);
+            expect(DEFAULT_HPA_CONFIG.maxEntranceWidth).toBe(16);
             expect(DEFAULT_HPA_CONFIG.cacheInternalPaths).toBe(true);
         });
 

--- a/packages/framework/pathfinding/__tests__/core/HPAPerformance.test.ts
+++ b/packages/framework/pathfinding/__tests__/core/HPAPerformance.test.ts
@@ -1,0 +1,92 @@
+/**
+ * HPA* 性能测试
+ */
+
+import { describe, it, expect } from 'vitest';
+import { HPAPathfinder } from '../../src/core/HPAPathfinder';
+import { AStarPathfinder } from '../../src/core/AStarPathfinder';
+import { GridMap } from '../../src/grid/GridMap';
+
+describe('HPA* Performance', () => {
+    it('should compare HPA* vs A* on huge map (1000x650)', () => {
+        const width = 1000;
+        const height = 650;
+        const map = new GridMap(width, height, { allowDiagonal: true });
+
+        // 生成 15% 障碍物
+        const obstacleRate = 0.15;
+        for (let y = 0; y < height; y++) {
+            for (let x = 0; x < width; x++) {
+                if (Math.random() < obstacleRate) {
+                    map.setWalkable(x, y, false);
+                }
+            }
+        }
+
+        // 确保起点终点可走
+        const startX = 10, startY = 10;
+        const endX = width - 10, endY = height - 10;
+        map.setWalkable(startX, startY, true);
+        map.setWalkable(endX, endY, true);
+
+        console.log(`\nMap size: ${width}x${height} = ${(width * height / 1000).toFixed(0)}K cells`);
+
+        // 增大 maxNodes 限制
+        const opts = { maxNodes: width * height };
+
+        // A* 测试
+        const astar = new AStarPathfinder(map);
+        const astarStart = performance.now();
+        const astarResult = astar.findPath(startX, startY, endX, endY, opts);
+        const astarTime = performance.now() - astarStart;
+
+        console.log(`A*: ${astarTime.toFixed(2)}ms, nodes: ${astarResult.nodesSearched}, path: ${astarResult.path.length}`);
+
+        // HPA* 测试 - 使用默认配置 (clusterSize=32)
+        const hpa = new HPAPathfinder(map);
+
+        const prepStart = performance.now();
+        hpa.preprocess();
+        const prepTime = performance.now() - prepStart;
+
+        const stats = hpa.getStats();
+        console.log(`HPA* prep: ${prepTime.toFixed(2)}ms, clusters: ${stats.clusters}, nodes: ${stats.abstractNodes}, cache: ${stats.cacheSize}`);
+
+        // 多次查询测试（第一次会有缓存开销）
+        const hpaStart = performance.now();
+        const hpaResult = hpa.findPath(startX, startY, endX, endY, opts);
+        const hpaTime = performance.now() - hpaStart;
+
+        // 第二次查询（可能更快）
+        const hpaStart2 = performance.now();
+        const hpaResult2 = hpa.findPath(startX, startY, endX, endY, opts);
+        const hpaTime2 = performance.now() - hpaStart2;
+
+        console.log(`HPA* find: ${hpaTime.toFixed(2)}ms (2nd: ${hpaTime2.toFixed(2)}ms), nodes: ${hpaResult.nodesSearched}, path: ${hpaResult.path.length}`);
+        console.log(`Speedup: ${(astarTime / hpaTime).toFixed(2)}x (query only)`);
+
+        expect(astarResult.found).toBe(true);
+        expect(hpaResult.found).toBe(true);
+    });
+
+    it('should test cluster internal path caching overhead', () => {
+        const width = 100;
+        const height = 100;
+        const map = new GridMap(width, height, { allowDiagonal: true });
+
+        const hpa = new HPAPathfinder(map, { clusterSize: 20 });
+
+        const prepStart = performance.now();
+        hpa.preprocess();
+        const prepTime = performance.now() - prepStart;
+
+        const stats = hpa.getStats();
+        console.log(`\n100x100 map prep: ${prepTime.toFixed(2)}ms`);
+        console.log(`Clusters: ${stats.clusters}, Abstract nodes: ${stats.abstractNodes}, Cache size: ${stats.cacheSize}`);
+
+        // 每个 cluster 的入口对数量
+        const nodesPerCluster = stats.abstractNodes / stats.clusters;
+        const pairsPerCluster = (nodesPerCluster * (nodesPerCluster - 1)) / 2;
+        console.log(`Avg nodes/cluster: ${nodesPerCluster.toFixed(1)}, pairs/cluster: ${pairsPerCluster.toFixed(1)}`);
+    });
+});

--- a/packages/framework/pathfinding/src/core/HPAPathfinder.ts
+++ b/packages/framework/pathfinding/src/core/HPAPathfinder.ts
@@ -9,28 +9,32 @@
  * 1. 将地图划分为集群 (clusters)
  * 2. 在集群边界检测入口点 (entrances)
  * 3. 构建抽象图 (abstract graph) 连接入口点
- * 4. 先在抽象图上寻路，再细化为详细路径
+ * 4. 预计算集群内入口点之间的真实路径代价
+ * 5. 先在抽象图上寻路，再利用缓存细化为详细路径
  *
  * @en How it works:
  * 1. Divide map into clusters
  * 2. Detect entrances at cluster boundaries
  * 3. Build abstract graph connecting entrances
- * 4. First find path on abstract graph, then refine to detailed path
+ * 4. Precompute actual path costs between entrances within clusters
+ * 5. First find path on abstract graph, then refine using cached paths
  */
 
-import { BinaryHeap } from './BinaryHeap';
+import { IndexedBinaryHeap, IHeapIndexable } from './IndexedBinaryHeap';
 import type {
     IPathfindingMap,
     IPoint,
     IPathResult,
     IPathfinder,
-    IPathfindingOptions
+    IPathfindingOptions,
+    IPathNode
 } from './IPathfinding';
 import { DEFAULT_PATHFINDING_OPTIONS, EMPTY_PATH_RESULT } from './IPathfinding';
 import { AStarPathfinder } from './AStarPathfinder';
+import { PathCache } from './PathCache';
 
 // =============================================================================
-// 配置 | Configuration
+// 类型定义 | Type Definitions
 // =============================================================================
 
 /**
@@ -45,8 +49,8 @@ export interface IHPAConfig {
     clusterSize: number;
 
     /**
-     * @zh 最大入口宽度（超过此宽度会拆分为多个入口）
-     * @en Maximum entrance width (entrances wider than this will be split)
+     * @zh 最大入口宽度（超过此宽度会拆分或使用端点策略）
+     * @en Maximum entrance width (entrances wider than this will be split or use endpoint strategy)
      */
     maxEntranceWidth: number;
 
@@ -55,6 +59,18 @@ export interface IHPAConfig {
      * @en Whether to enable internal path caching
      */
     cacheInternalPaths: boolean;
+
+    /**
+     * @zh 入口策略：'middle' 在中间放节点，'end' 在宽入口两端各放节点
+     * @en Entrance strategy: 'middle' places node at center, 'end' places nodes at both ends for wide entrances
+     */
+    entranceStrategy?: 'middle' | 'end';
+
+    /**
+     * @zh 是否延迟计算 intra-edges（大幅加速预处理，首次查询时计算真实路径）
+     * @en Whether to lazily compute intra-edges (greatly speeds up preprocessing, computes actual paths on first query)
+     */
+    lazyIntraEdges?: boolean;
 }
 
 /**
@@ -62,39 +78,26 @@ export interface IHPAConfig {
  * @en Default HPA* configuration
  */
 export const DEFAULT_HPA_CONFIG: IHPAConfig = {
-    clusterSize: 10,
-    maxEntranceWidth: 6,
-    cacheInternalPaths: true
+    clusterSize: 64,
+    maxEntranceWidth: 16,
+    cacheInternalPaths: true,
+    entranceStrategy: 'end',
+    lazyIntraEdges: true
 };
 
-// =============================================================================
-// 内部类型 | Internal Types
-// =============================================================================
-
 /**
- * @zh 集群
- * @en Cluster
+ * @zh 抽象边信息
+ * @en Abstract edge information
  */
-interface Cluster {
-    id: number;
-    x: number;
-    y: number;
-    width: number;
-    height: number;
-    entrances: Entrance[];
-}
-
-/**
- * @zh 入口（集群之间的连接点）
- * @en Entrance (connection point between clusters)
- */
-interface Entrance {
-    id: number;
-    cluster1Id: number;
-    cluster2Id: number;
-    point1: IPoint;
-    point2: IPoint;
-    center: IPoint;
+interface AbstractEdge {
+    /** @zh 目标节点 ID @en Target node ID */
+    targetNodeId: number;
+    /** @zh 边代价（真实路径代价）@en Edge cost (actual path cost) */
+    cost: number;
+    /** @zh 是否为跨集群边 @en Is inter-cluster edge */
+    isInterEdge: boolean;
+    /** @zh 缓存的具体路径（ConcreteNodeId 列表）@en Cached concrete path (ConcreteNodeId list) */
+    innerPath: number[] | null;
 }
 
 /**
@@ -102,33 +105,293 @@ interface Entrance {
  * @en Abstract node
  */
 interface AbstractNode {
+    /** @zh 节点 ID @en Node ID */
     id: number;
+    /** @zh 位置（地图坐标）@en Position (map coordinates) */
     position: IPoint;
+    /** @zh 所属集群 ID @en Cluster ID */
     clusterId: number;
-    entranceId: number;
+    /** @zh 对应的具体地图节点 ID (y * width + x) @en Corresponding concrete node ID */
+    concreteNodeId: number;
+    /** @zh 出边列表 @en Outgoing edges */
     edges: AbstractEdge[];
-}
-
-/**
- * @zh 抽象边
- * @en Abstract edge
- */
-interface AbstractEdge {
-    targetNodeId: number;
-    cost: number;
-    isInterEdge: boolean;
 }
 
 /**
  * @zh A* 搜索节点
  * @en A* search node
  */
-interface SearchNode {
-    abstractNode: AbstractNode;
+interface SearchNode extends IHeapIndexable {
+    node: AbstractNode;
     g: number;
     h: number;
     f: number;
     parent: SearchNode | null;
+    closed: boolean;
+    opened: boolean;
+    heapIndex: number;
+}
+
+/**
+ * @zh 入口区间（边界上连续可通行的区域）
+ * @en Entrance span (continuous walkable region on boundary)
+ */
+interface EntranceSpan {
+    start: number;
+    end: number;
+}
+
+// =============================================================================
+// SubMap 子地图类 (Slice) | SubMap Class (Slice)
+// =============================================================================
+
+/**
+ * @zh 子地图 - 为集群提供隔离的地图视图
+ * @en SubMap - Provides isolated map view for cluster
+ *
+ * @zh 不复制数据，只做坐标转换并委托给父地图
+ * @en Doesn't copy data, just transforms coordinates and delegates to parent map
+ */
+class SubMap implements IPathfindingMap {
+    readonly width: number;
+    readonly height: number;
+
+    constructor(
+        private readonly parentMap: IPathfindingMap,
+        private readonly originX: number,
+        private readonly originY: number,
+        width: number,
+        height: number
+    ) {
+        this.width = width;
+        this.height = height;
+    }
+
+    /**
+     * @zh 局部坐标转全局坐标
+     * @en Convert local to global coordinates
+     */
+    localToGlobal(localX: number, localY: number): IPoint {
+        return {
+            x: this.originX + localX,
+            y: this.originY + localY
+        };
+    }
+
+    /**
+     * @zh 全局坐标转局部坐标
+     * @en Convert global to local coordinates
+     */
+    globalToLocal(globalX: number, globalY: number): IPoint {
+        return {
+            x: globalX - this.originX,
+            y: globalY - this.originY
+        };
+    }
+
+    isWalkable(x: number, y: number): boolean {
+        if (x < 0 || x >= this.width || y < 0 || y >= this.height) {
+            return false;
+        }
+        return this.parentMap.isWalkable(this.originX + x, this.originY + y);
+    }
+
+    getNodeAt(x: number, y: number): IPathNode | null {
+        if (x < 0 || x >= this.width || y < 0 || y >= this.height) {
+            return null;
+        }
+        const globalNode = this.parentMap.getNodeAt(this.originX + x, this.originY + y);
+        if (!globalNode) return null;
+
+        // 创建局部节点（调整坐标）
+        return {
+            id: y * this.width + x,
+            position: { x, y },
+            cost: globalNode.cost,
+            walkable: globalNode.walkable
+        };
+    }
+
+    getNeighbors(node: IPathNode): IPathNode[] {
+        const neighbors: IPathNode[] = [];
+        const { x, y } = node.position;
+
+        // 8方向邻居
+        const directions = [
+            { dx: 0, dy: -1 },  // N
+            { dx: 1, dy: -1 },  // NE
+            { dx: 1, dy: 0 },   // E
+            { dx: 1, dy: 1 },   // SE
+            { dx: 0, dy: 1 },   // S
+            { dx: -1, dy: 1 },  // SW
+            { dx: -1, dy: 0 },  // W
+            { dx: -1, dy: -1 }  // NW
+        ];
+
+        for (const dir of directions) {
+            const nx = x + dir.dx;
+            const ny = y + dir.dy;
+
+            if (nx < 0 || nx >= this.width || ny < 0 || ny >= this.height) {
+                continue;
+            }
+
+            if (!this.isWalkable(nx, ny)) {
+                continue;
+            }
+
+            // 对角线移动：检查是否被角落阻挡
+            if (dir.dx !== 0 && dir.dy !== 0) {
+                if (!this.isWalkable(x + dir.dx, y) || !this.isWalkable(x, y + dir.dy)) {
+                    continue;
+                }
+            }
+
+            const neighborNode = this.getNodeAt(nx, ny);
+            if (neighborNode) {
+                neighbors.push(neighborNode);
+            }
+        }
+
+        return neighbors;
+    }
+
+    heuristic(a: IPoint, b: IPoint): number {
+        // Octile 距离
+        const dx = Math.abs(a.x - b.x);
+        const dy = Math.abs(a.y - b.y);
+        return dx + dy + (Math.SQRT2 - 2) * Math.min(dx, dy);
+    }
+
+    getMovementCost(from: IPathNode, to: IPathNode): number {
+        const dx = Math.abs(to.position.x - from.position.x);
+        const dy = Math.abs(to.position.y - from.position.y);
+        const baseCost = (dx !== 0 && dy !== 0) ? Math.SQRT2 : 1;
+        return baseCost * to.cost;
+    }
+}
+
+// =============================================================================
+// Cluster 集群类 | Cluster Class
+// =============================================================================
+
+/**
+ * @zh 集群 - 管理地图的一个区域
+ * @en Cluster - Manages a region of the map
+ */
+class Cluster {
+    readonly id: number;
+    readonly originX: number;
+    readonly originY: number;
+    readonly width: number;
+    readonly height: number;
+    readonly subMap: SubMap;
+
+    /** @zh 集群内的抽象节点 ID 列表 @en Abstract node IDs in this cluster */
+    nodeIds: number[] = [];
+
+    /** @zh 预计算的距离缓存 @en Precomputed distance cache */
+    private readonly distanceCache: Map<string, number> = new Map();
+
+    /** @zh 预计算的路径缓存 @en Precomputed path cache */
+    private readonly pathCache: Map<string, number[]> = new Map();
+
+    constructor(
+        id: number,
+        originX: number,
+        originY: number,
+        width: number,
+        height: number,
+        parentMap: IPathfindingMap
+    ) {
+        this.id = id;
+        this.originX = originX;
+        this.originY = originY;
+        this.width = width;
+        this.height = height;
+        this.subMap = new SubMap(parentMap, originX, originY, width, height);
+    }
+
+    /**
+     * @zh 检查点是否在集群内
+     * @en Check if point is in cluster
+     */
+    containsPoint(x: number, y: number): boolean {
+        return x >= this.originX && x < this.originX + this.width &&
+               y >= this.originY && y < this.originY + this.height;
+    }
+
+    /**
+     * @zh 添加节点 ID
+     * @en Add node ID
+     */
+    addNodeId(nodeId: number): void {
+        if (!this.nodeIds.includes(nodeId)) {
+            this.nodeIds.push(nodeId);
+        }
+    }
+
+    /**
+     * @zh 移除节点 ID
+     * @en Remove node ID
+     */
+    removeNodeId(nodeId: number): void {
+        const idx = this.nodeIds.indexOf(nodeId);
+        if (idx !== -1) {
+            this.nodeIds.splice(idx, 1);
+        }
+    }
+
+    /**
+     * @zh 生成缓存键
+     * @en Generate cache key
+     */
+    private getCacheKey(fromId: number, toId: number): string {
+        return `${fromId}->${toId}`;
+    }
+
+    /**
+     * @zh 设置缓存
+     * @en Set cache
+     */
+    setCache(fromId: number, toId: number, cost: number, path: number[]): void {
+        const key = this.getCacheKey(fromId, toId);
+        this.distanceCache.set(key, cost);
+        this.pathCache.set(key, path);
+    }
+
+    /**
+     * @zh 获取缓存的距离
+     * @en Get cached distance
+     */
+    getCachedDistance(fromId: number, toId: number): number | undefined {
+        return this.distanceCache.get(this.getCacheKey(fromId, toId));
+    }
+
+    /**
+     * @zh 获取缓存的路径
+     * @en Get cached path
+     */
+    getCachedPath(fromId: number, toId: number): number[] | undefined {
+        return this.pathCache.get(this.getCacheKey(fromId, toId));
+    }
+
+    /**
+     * @zh 清除缓存
+     * @en Clear cache
+     */
+    clearCache(): void {
+        this.distanceCache.clear();
+        this.pathCache.clear();
+    }
+
+    /**
+     * @zh 获取缓存大小
+     * @en Get cache size
+     */
+    getCacheSize(): number {
+        return this.distanceCache.size;
+    }
 }
 
 // =============================================================================
@@ -156,53 +419,64 @@ interface SearchNode {
  */
 export class HPAPathfinder implements IPathfinder {
     private readonly map: IPathfindingMap;
-    private readonly config: IHPAConfig;
-    private readonly width: number;
-    private readonly height: number;
+    private readonly config: Required<IHPAConfig>;
+    private readonly mapWidth: number;
+    private readonly mapHeight: number;
 
+    // 集群管理
     private clusters: Cluster[] = [];
-    private entrances: Entrance[] = [];
-    private abstractNodes: Map<number, AbstractNode> = new Map();
-    private clusterGrid: (Cluster | null)[][] = [];
+    private clusterGrid: (number | null)[][] = [];  // [cx][cy] -> clusterId
+    private clustersX: number = 0;
+    private clustersY: number = 0;
 
-    private nextEntranceId: number = 0;
+    // 抽象图
+    private abstractNodes: Map<number, AbstractNode> = new Map();
+    private nodesByCluster: Map<number, number[]> = new Map();
     private nextNodeId: number = 0;
 
-    private internalPathCache: Map<string, IPoint[]> = new Map();
-    private localPathfinder: AStarPathfinder;
+    // 入口统计
+    private entranceCount: number = 0;
+
+    // 内部寻路器
+    private readonly localPathfinder: AStarPathfinder;
+
+    // 完整路径缓存
+    private readonly pathCache: PathCache;
+    private mapVersion: number = 0;
 
     private preprocessed: boolean = false;
 
     constructor(map: IPathfindingMap, config?: Partial<IHPAConfig>) {
         this.map = map;
-        this.config = { ...DEFAULT_HPA_CONFIG, ...config };
+        this.config = { ...DEFAULT_HPA_CONFIG, ...config } as Required<IHPAConfig>;
 
         const bounds = this.getMapBounds();
-        this.width = bounds.width;
-        this.height = bounds.height;
+        this.mapWidth = bounds.width;
+        this.mapHeight = bounds.height;
 
         this.localPathfinder = new AStarPathfinder(map);
+        this.pathCache = new PathCache({ maxEntries: 1000, ttlMs: 0 });
     }
+
+    // =========================================================================
+    // 公共 API | Public API
+    // =========================================================================
 
     /**
      * @zh 预处理地图（构建抽象图）
      * @en Preprocess map (build abstract graph)
-     *
-     * @zh 在地图变化后需要重新调用
-     * @en Need to call again after map changes
      */
     preprocess(): void {
-        this.clusters = [];
-        this.entrances = [];
-        this.abstractNodes.clear();
-        this.clusterGrid = [];
-        this.internalPathCache.clear();
-        this.nextEntranceId = 0;
-        this.nextNodeId = 0;
+        this.clear();
 
+        // 1. 构建集群
         this.buildClusters();
-        this.findEntrances();
-        this.buildAbstractGraph();
+
+        // 2. 检测入口并创建抽象节点
+        this.buildEntrances();
+
+        // 3. 创建集群内边（计算真实代价）
+        this.buildIntraEdges();
 
         this.preprocessed = true;
     }
@@ -224,10 +498,12 @@ export class HPAPathfinder implements IPathfinder {
 
         const opts = { ...DEFAULT_PATHFINDING_OPTIONS, ...options };
 
+        // 验证起点终点
         if (!this.map.isWalkable(startX, startY) || !this.map.isWalkable(endX, endY)) {
             return EMPTY_PATH_RESULT;
         }
 
+        // 同一点
         if (startX === endX && startY === endY) {
             return {
                 found: true,
@@ -237,6 +513,12 @@ export class HPAPathfinder implements IPathfinder {
             };
         }
 
+        // 检查路径缓存
+        const cached = this.pathCache.get(startX, startY, endX, endY, this.mapVersion);
+        if (cached) {
+            return cached;
+        }
+
         const startCluster = this.getClusterAt(startX, startY);
         const endCluster = this.getClusterAt(endX, endY);
 
@@ -244,23 +526,34 @@ export class HPAPathfinder implements IPathfinder {
             return EMPTY_PATH_RESULT;
         }
 
+        let result: IPathResult;
+
+        // 同一集群：直接局部搜索
         if (startCluster.id === endCluster.id) {
-            return this.findLocalPath(startX, startY, endX, endY, opts);
+            result = this.findLocalPath(startX, startY, endX, endY, opts);
+        } else {
+            // 跨集群：HPA* 搜索
+            const startTemp = this.insertTempNode(startX, startY, startCluster);
+            const endTemp = this.insertTempNode(endX, endY, endCluster);
+
+            const abstractPath = this.abstractSearch(startTemp, endTemp, opts);
+
+            this.removeTempNode(startTemp, startCluster);
+            this.removeTempNode(endTemp, endCluster);
+
+            if (!abstractPath || abstractPath.length === 0) {
+                return EMPTY_PATH_RESULT;
+            }
+
+            result = this.refinePath(abstractPath, startX, startY, endX, endY, opts);
         }
 
-        const startNodes = this.insertTemporaryNode(startX, startY, startCluster);
-        const endNodes = this.insertTemporaryNode(endX, endY, endCluster);
-
-        const abstractPath = this.searchAbstractGraph(startNodes, endNodes, opts);
-
-        this.removeTemporaryNodes(startNodes);
-        this.removeTemporaryNodes(endNodes);
-
-        if (!abstractPath || abstractPath.length === 0) {
-            return EMPTY_PATH_RESULT;
+        // 缓存结果
+        if (result.found) {
+            this.pathCache.set(startX, startY, endX, endY, result, this.mapVersion);
         }
 
-        return this.refinePath(abstractPath, startX, startY, endX, endY, opts);
+        return result;
     }
 
     /**
@@ -269,10 +562,13 @@ export class HPAPathfinder implements IPathfinder {
      */
     clear(): void {
         this.clusters = [];
-        this.entrances = [];
-        this.abstractNodes.clear();
         this.clusterGrid = [];
-        this.internalPathCache.clear();
+        this.abstractNodes.clear();
+        this.nodesByCluster.clear();
+        this.nextNodeId = 0;
+        this.entranceCount = 0;
+        this.pathCache.invalidateAll();
+        this.mapVersion++;
         this.preprocessed = false;
     }
 
@@ -281,8 +577,27 @@ export class HPAPathfinder implements IPathfinder {
      * @en Notify map region change
      */
     notifyRegionChange(minX: number, minY: number, maxX: number, maxY: number): void {
-        this.preprocessed = false;
-        this.internalPathCache.clear();
+        // 找出受影响的集群并重建其 intra-edges
+        const affectedClusters = this.getAffectedClusters(minX, minY, maxX, maxY);
+
+        for (const cluster of affectedClusters) {
+            // 清除该集群的缓存
+            cluster.clearCache();
+
+            // 移除该集群内所有节点的 intra-edges
+            for (const nodeId of cluster.nodeIds) {
+                const node = this.abstractNodes.get(nodeId);
+                if (node) {
+                    node.edges = node.edges.filter(e => e.isInterEdge);
+                }
+            }
+
+            // 重建 intra-edges
+            this.buildClusterIntraEdges(cluster);
+        }
+
+        this.pathCache.invalidateRegion(minX, minY, maxX, maxY);
+        this.mapVersion++;
     }
 
     /**
@@ -295,11 +610,16 @@ export class HPAPathfinder implements IPathfinder {
         abstractNodes: number;
         cacheSize: number;
     } {
+        let cacheSize = 0;
+        for (const cluster of this.clusters) {
+            cacheSize += cluster.getCacheSize();
+        }
+
         return {
             clusters: this.clusters.length,
-            entrances: this.entrances.length,
+            entrances: this.entranceCount,
             abstractNodes: this.abstractNodes.size,
-            cacheSize: this.internalPathCache.size
+            cacheSize
         };
     }
 
@@ -315,334 +635,729 @@ export class HPAPathfinder implements IPathfinder {
         return { width: 1000, height: 1000 };
     }
 
+    /**
+     * @zh 构建集群
+     * @en Build clusters
+     */
     private buildClusters(): void {
         const clusterSize = this.config.clusterSize;
-        const clustersX = Math.ceil(this.width / clusterSize);
-        const clustersY = Math.ceil(this.height / clusterSize);
+        this.clustersX = Math.ceil(this.mapWidth / clusterSize);
+        this.clustersY = Math.ceil(this.mapHeight / clusterSize);
 
+        // 初始化集群网格
         this.clusterGrid = [];
-        for (let x = 0; x < clustersX; x++) {
-            this.clusterGrid[x] = [];
+        for (let cx = 0; cx < this.clustersX; cx++) {
+            this.clusterGrid[cx] = [];
+            for (let cy = 0; cy < this.clustersY; cy++) {
+                this.clusterGrid[cx][cy] = null;
+            }
         }
 
+        // 创建集群
         let clusterId = 0;
-        for (let cy = 0; cy < clustersY; cy++) {
-            for (let cx = 0; cx < clustersX; cx++) {
-                const cluster: Cluster = {
-                    id: clusterId++,
-                    x: cx * clusterSize,
-                    y: cy * clusterSize,
-                    width: Math.min(clusterSize, this.width - cx * clusterSize),
-                    height: Math.min(clusterSize, this.height - cy * clusterSize),
-                    entrances: []
-                };
+        for (let cy = 0; cy < this.clustersY; cy++) {
+            for (let cx = 0; cx < this.clustersX; cx++) {
+                const originX = cx * clusterSize;
+                const originY = cy * clusterSize;
+                const width = Math.min(clusterSize, this.mapWidth - originX);
+                const height = Math.min(clusterSize, this.mapHeight - originY);
+
+                const cluster = new Cluster(
+                    clusterId,
+                    originX,
+                    originY,
+                    width,
+                    height,
+                    this.map
+                );
+
                 this.clusters.push(cluster);
-                this.clusterGrid[cx][cy] = cluster;
+                this.clusterGrid[cx][cy] = clusterId;
+                this.nodesByCluster.set(clusterId, []);
+                clusterId++;
             }
         }
     }
 
-    private findEntrances(): void {
+    /**
+     * @zh 检测入口并创建抽象节点
+     * @en Detect entrances and create abstract nodes
+     */
+    private buildEntrances(): void {
         const clusterSize = this.config.clusterSize;
-        const clustersX = Math.ceil(this.width / clusterSize);
-        const clustersY = Math.ceil(this.height / clusterSize);
 
-        for (let cy = 0; cy < clustersY; cy++) {
-            for (let cx = 0; cx < clustersX; cx++) {
-                const cluster = this.clusterGrid[cx][cy];
-                if (!cluster) continue;
+        for (let cy = 0; cy < this.clustersY; cy++) {
+            for (let cx = 0; cx < this.clustersX; cx++) {
+                const clusterId = this.clusterGrid[cx][cy];
+                if (clusterId === null) continue;
 
-                if (cx < clustersX - 1) {
-                    const rightCluster = this.clusterGrid[cx + 1]?.[cy];
-                    if (rightCluster) {
-                        this.findEntrancesBetween(cluster, rightCluster, 'horizontal');
+                const cluster1 = this.clusters[clusterId];
+
+                // 右边相邻集群
+                if (cx < this.clustersX - 1) {
+                    const cluster2Id = this.clusterGrid[cx + 1][cy];
+                    if (cluster2Id !== null) {
+                        const cluster2 = this.clusters[cluster2Id];
+                        this.detectAndCreateEntrances(cluster1, cluster2, 'vertical');
                     }
                 }
 
-                if (cy < clustersY - 1) {
-                    const bottomCluster = this.clusterGrid[cx]?.[cy + 1];
-                    if (bottomCluster) {
-                        this.findEntrancesBetween(cluster, bottomCluster, 'vertical');
+                // 下边相邻集群
+                if (cy < this.clustersY - 1) {
+                    const cluster2Id = this.clusterGrid[cx][cy + 1];
+                    if (cluster2Id !== null) {
+                        const cluster2 = this.clusters[cluster2Id];
+                        this.detectAndCreateEntrances(cluster1, cluster2, 'horizontal');
                     }
                 }
             }
         }
     }
 
-    private findEntrancesBetween(
+    /**
+     * @zh 检测并创建两个相邻集群之间的入口
+     * @en Detect and create entrances between two adjacent clusters
+     */
+    private detectAndCreateEntrances(
         cluster1: Cluster,
         cluster2: Cluster,
-        direction: 'horizontal' | 'vertical'
+        boundaryDirection: 'horizontal' | 'vertical'
     ): void {
-        const maxWidth = this.config.maxEntranceWidth;
-        let entranceStart: number | null = null;
-        let entranceLength = 0;
+        const spans = this.detectEntranceSpans(cluster1, cluster2, boundaryDirection);
 
-        if (direction === 'horizontal') {
-            const x1 = cluster1.x + cluster1.width - 1;
-            const x2 = cluster2.x;
-            const startY = Math.max(cluster1.y, cluster2.y);
-            const endY = Math.min(cluster1.y + cluster1.height, cluster2.y + cluster2.height);
+        for (const span of spans) {
+            this.createEntranceNodes(cluster1, cluster2, span, boundaryDirection);
+        }
+    }
+
+    /**
+     * @zh 检测边界上的连续可通行区间
+     * @en Detect continuous walkable spans on boundary
+     */
+    private detectEntranceSpans(
+        cluster1: Cluster,
+        cluster2: Cluster,
+        boundaryDirection: 'horizontal' | 'vertical'
+    ): EntranceSpan[] {
+        const spans: EntranceSpan[] = [];
+
+        if (boundaryDirection === 'vertical') {
+            // cluster1 在左，cluster2 在右
+            const x1 = cluster1.originX + cluster1.width - 1;
+            const x2 = cluster2.originX;
+            const startY = Math.max(cluster1.originY, cluster2.originY);
+            const endY = Math.min(
+                cluster1.originY + cluster1.height,
+                cluster2.originY + cluster2.height
+            );
+
+            let spanStart: number | null = null;
 
             for (let y = startY; y < endY; y++) {
                 const walkable1 = this.map.isWalkable(x1, y);
                 const walkable2 = this.map.isWalkable(x2, y);
 
                 if (walkable1 && walkable2) {
-                    if (entranceStart === null) {
-                        entranceStart = y;
-                        entranceLength = 1;
-                    } else {
-                        entranceLength++;
+                    if (spanStart === null) {
+                        spanStart = y;
                     }
-
-                    if (entranceLength >= maxWidth || y === endY - 1) {
-                        this.createEntrance(cluster1, cluster2, x1, x2, entranceStart, entranceStart + entranceLength - 1, 'horizontal');
-                        entranceStart = null;
-                        entranceLength = 0;
+                } else {
+                    if (spanStart !== null) {
+                        spans.push({ start: spanStart, end: y - 1 });
+                        spanStart = null;
                     }
-                } else if (entranceStart !== null) {
-                    this.createEntrance(cluster1, cluster2, x1, x2, entranceStart, entranceStart + entranceLength - 1, 'horizontal');
-                    entranceStart = null;
-                    entranceLength = 0;
                 }
             }
+
+            if (spanStart !== null) {
+                spans.push({ start: spanStart, end: endY - 1 });
+            }
         } else {
-            const y1 = cluster1.y + cluster1.height - 1;
-            const y2 = cluster2.y;
-            const startX = Math.max(cluster1.x, cluster2.x);
-            const endX = Math.min(cluster1.x + cluster1.width, cluster2.x + cluster2.width);
+            // cluster1 在上，cluster2 在下
+            const y1 = cluster1.originY + cluster1.height - 1;
+            const y2 = cluster2.originY;
+            const startX = Math.max(cluster1.originX, cluster2.originX);
+            const endX = Math.min(
+                cluster1.originX + cluster1.width,
+                cluster2.originX + cluster2.width
+            );
+
+            let spanStart: number | null = null;
 
             for (let x = startX; x < endX; x++) {
                 const walkable1 = this.map.isWalkable(x, y1);
                 const walkable2 = this.map.isWalkable(x, y2);
 
                 if (walkable1 && walkable2) {
-                    if (entranceStart === null) {
-                        entranceStart = x;
-                        entranceLength = 1;
-                    } else {
-                        entranceLength++;
+                    if (spanStart === null) {
+                        spanStart = x;
                     }
+                } else {
+                    if (spanStart !== null) {
+                        spans.push({ start: spanStart, end: x - 1 });
+                        spanStart = null;
+                    }
+                }
+            }
 
-                    if (entranceLength >= maxWidth || x === endX - 1) {
-                        this.createEntrance(cluster1, cluster2, entranceStart, entranceStart + entranceLength - 1, y1, y2, 'vertical');
-                        entranceStart = null;
-                        entranceLength = 0;
-                    }
-                } else if (entranceStart !== null) {
-                    this.createEntrance(cluster1, cluster2, entranceStart, entranceStart + entranceLength - 1, y1, y2, 'vertical');
-                    entranceStart = null;
-                    entranceLength = 0;
+            if (spanStart !== null) {
+                spans.push({ start: spanStart, end: endX - 1 });
+            }
+        }
+
+        return spans;
+    }
+
+    /**
+     * @zh 为入口区间创建抽象节点
+     * @en Create abstract nodes for entrance span
+     */
+    private createEntranceNodes(
+        cluster1: Cluster,
+        cluster2: Cluster,
+        span: EntranceSpan,
+        boundaryDirection: 'horizontal' | 'vertical'
+    ): void {
+        const spanLength = span.end - span.start + 1;
+        const maxWidth = this.config.maxEntranceWidth;
+        const strategy = this.config.entranceStrategy;
+
+        // 确定要放置节点的位置
+        const positions: number[] = [];
+
+        if (spanLength <= maxWidth) {
+            // 窄入口：放在中间
+            positions.push(Math.floor((span.start + span.end) / 2));
+        } else {
+            // 宽入口：均匀分布多个节点
+            // Wide entrance: distribute multiple nodes evenly
+            const numNodes = Math.ceil(spanLength / maxWidth);
+            const spacing = spanLength / numNodes;
+
+            for (let i = 0; i < numNodes; i++) {
+                // 在每个子区间的中心放置节点
+                const pos = Math.floor(span.start + spacing * (i + 0.5));
+                positions.push(Math.min(pos, span.end));
+            }
+
+            // 如果使用 'end' 策略，确保两端也有节点
+            if (strategy === 'end') {
+                if (!positions.includes(span.start)) {
+                    positions.unshift(span.start);
+                }
+                if (!positions.includes(span.end)) {
+                    positions.push(span.end);
                 }
             }
         }
-    }
 
-    private createEntrance(
-        cluster1: Cluster,
-        cluster2: Cluster,
-        coord1Start: number,
-        coord1End: number,
-        coord2Start: number,
-        coord2End: number,
-        direction: 'horizontal' | 'vertical'
-    ): void {
-        let point1: IPoint;
-        let point2: IPoint;
-        let center: IPoint;
+        // 为每个位置创建节点对
+        for (const pos of positions) {
+            let p1: IPoint, p2: IPoint;
 
-        if (direction === 'horizontal') {
-            const midY = Math.floor((coord1Start + coord1End) / 2);
-            point1 = { x: coord1Start, y: midY };
-            point2 = { x: coord2Start, y: midY };
-            center = { x: coord1Start, y: midY };
-        } else {
-            const midX = Math.floor((coord1Start + coord1End) / 2);
-            point1 = { x: midX, y: coord2Start };
-            point2 = { x: midX, y: coord2End };
-            center = { x: midX, y: coord2Start };
-        }
+            if (boundaryDirection === 'vertical') {
+                // cluster1 在左，cluster2 在右
+                p1 = { x: cluster1.originX + cluster1.width - 1, y: pos };
+                p2 = { x: cluster2.originX, y: pos };
+            } else {
+                // cluster1 在上，cluster2 在下
+                p1 = { x: pos, y: cluster1.originY + cluster1.height - 1 };
+                p2 = { x: pos, y: cluster2.originY };
+            }
 
-        const entrance: Entrance = {
-            id: this.nextEntranceId++,
-            cluster1Id: cluster1.id,
-            cluster2Id: cluster2.id,
-            point1,
-            point2,
-            center
-        };
+            // 创建节点对
+            const node1 = this.createAbstractNode(p1, cluster1);
+            const node2 = this.createAbstractNode(p2, cluster2);
 
-        this.entrances.push(entrance);
-        cluster1.entrances.push(entrance);
-        cluster2.entrances.push(entrance);
-    }
+            // 创建 inter-edge（代价为 1，相邻格子）
+            const interCost = 1;
 
-    private buildAbstractGraph(): void {
-        for (const entrance of this.entrances) {
-            const node1 = this.createAbstractNode(entrance.point1, entrance.cluster1Id, entrance.id);
-            const node2 = this.createAbstractNode(entrance.point2, entrance.cluster2Id, entrance.id);
+            node1.edges.push({
+                targetNodeId: node2.id,
+                cost: interCost,
+                isInterEdge: true,
+                innerPath: null
+            });
 
-            node1.edges.push({ targetNodeId: node2.id, cost: 1, isInterEdge: true });
-            node2.edges.push({ targetNodeId: node1.id, cost: 1, isInterEdge: true });
-        }
+            node2.edges.push({
+                targetNodeId: node1.id,
+                cost: interCost,
+                isInterEdge: true,
+                innerPath: null
+            });
 
-        for (const cluster of this.clusters) {
-            this.connectIntraClusterNodes(cluster);
+            this.entranceCount++;
         }
     }
 
-    private createAbstractNode(position: IPoint, clusterId: number, entranceId: number): AbstractNode {
+    /**
+     * @zh 创建抽象节点
+     * @en Create abstract node
+     */
+    private createAbstractNode(position: IPoint, cluster: Cluster): AbstractNode {
+        // 检查是否已存在相同位置的节点
+        const concreteId = position.y * this.mapWidth + position.x;
+
+        for (const nodeId of cluster.nodeIds) {
+            const existing = this.abstractNodes.get(nodeId);
+            if (existing && existing.concreteNodeId === concreteId) {
+                return existing;
+            }
+        }
+
+        // 创建新节点
         const node: AbstractNode = {
             id: this.nextNodeId++,
-            position,
-            clusterId,
-            entranceId,
+            position: { x: position.x, y: position.y },
+            clusterId: cluster.id,
+            concreteNodeId: concreteId,
             edges: []
         };
+
         this.abstractNodes.set(node.id, node);
+        cluster.addNodeId(node.id);
+
+        const clusterNodes = this.nodesByCluster.get(cluster.id);
+        if (clusterNodes) {
+            clusterNodes.push(node.id);
+        }
+
         return node;
     }
 
-    private connectIntraClusterNodes(cluster: Cluster): void {
-        const nodesInCluster: AbstractNode[] = [];
+    /**
+     * @zh 构建所有集群的 intra-edges
+     * @en Build intra-edges for all clusters
+     */
+    private buildIntraEdges(): void {
+        for (const cluster of this.clusters) {
+            this.buildClusterIntraEdges(cluster);
+        }
+    }
 
-        for (const node of this.abstractNodes.values()) {
-            if (node.clusterId === cluster.id) {
-                nodesInCluster.push(node);
+    /**
+     * @zh 构建单个集群的 intra-edges
+     * @en Build intra-edges for single cluster
+     */
+    private buildClusterIntraEdges(cluster: Cluster): void {
+        const nodeIds = cluster.nodeIds;
+
+        if (nodeIds.length < 2) return;
+
+        if (this.config.lazyIntraEdges) {
+            // 延迟计算模式：只用启发式距离创建边，真实路径在首次使用时计算
+            this.buildLazyIntraEdges(cluster);
+        } else {
+            // 立即计算模式：预处理时计算所有真实路径
+            this.buildEagerIntraEdges(cluster);
+        }
+    }
+
+    /**
+     * @zh 延迟构建 intra-edges（只用启发式距离）
+     * @en Build lazy intra-edges (using heuristic distance only)
+     */
+    private buildLazyIntraEdges(cluster: Cluster): void {
+        const nodeIds = cluster.nodeIds;
+
+        for (let i = 0; i < nodeIds.length; i++) {
+            for (let j = i + 1; j < nodeIds.length; j++) {
+                const node1 = this.abstractNodes.get(nodeIds[i])!;
+                const node2 = this.abstractNodes.get(nodeIds[j])!;
+
+                // 使用启发式距离作为估计代价
+                const heuristicCost = this.heuristic(node1.position, node2.position);
+
+                // 创建双向 intra-edge（innerPath = null 表示未计算）
+                node1.edges.push({
+                    targetNodeId: node2.id,
+                    cost: heuristicCost,
+                    isInterEdge: false,
+                    innerPath: null  // 标记为未计算
+                });
+
+                node2.edges.push({
+                    targetNodeId: node1.id,
+                    cost: heuristicCost,
+                    isInterEdge: false,
+                    innerPath: null
+                });
             }
         }
+    }
 
-        for (let i = 0; i < nodesInCluster.length; i++) {
-            for (let j = i + 1; j < nodesInCluster.length; j++) {
-                const node1 = nodesInCluster[i];
-                const node2 = nodesInCluster[j];
+    /**
+     * @zh 立即构建 intra-edges（计算真实路径）
+     * @en Build eager intra-edges (compute actual paths)
+     */
+    private buildEagerIntraEdges(cluster: Cluster): void {
+        const nodeIds = cluster.nodeIds;
 
-                const cost = this.heuristic(node1.position, node2.position);
-                node1.edges.push({ targetNodeId: node2.id, cost, isInterEdge: false });
-                node2.edges.push({ targetNodeId: node1.id, cost, isInterEdge: false });
+        // 为子地图创建 A* 寻路器
+        const subPathfinder = new AStarPathfinder(cluster.subMap);
+
+        // 计算所有节点对之间的真实路径
+        for (let i = 0; i < nodeIds.length; i++) {
+            for (let j = i + 1; j < nodeIds.length; j++) {
+                const node1 = this.abstractNodes.get(nodeIds[i])!;
+                const node2 = this.abstractNodes.get(nodeIds[j])!;
+
+                // 转换为局部坐标
+                const local1 = cluster.subMap.globalToLocal(node1.position.x, node1.position.y);
+                const local2 = cluster.subMap.globalToLocal(node2.position.x, node2.position.y);
+
+                // A* 计算真实路径
+                const result = subPathfinder.findPath(
+                    local1.x, local1.y,
+                    local2.x, local2.y
+                );
+
+                if (result.found && result.path.length > 0) {
+                    // 转换路径为全局 ConcreteNodeId
+                    const globalPath: number[] = result.path.map(p => {
+                        const global = cluster.subMap.localToGlobal(p.x, p.y);
+                        return global.y * this.mapWidth + global.x;
+                    });
+
+                    // 缓存到集群
+                    if (this.config.cacheInternalPaths) {
+                        cluster.setCache(node1.id, node2.id, result.cost, globalPath);
+                        cluster.setCache(node2.id, node1.id, result.cost, [...globalPath].reverse());
+                    }
+
+                    // 创建双向 intra-edge
+                    node1.edges.push({
+                        targetNodeId: node2.id,
+                        cost: result.cost,
+                        isInterEdge: false,
+                        innerPath: this.config.cacheInternalPaths ? globalPath : null
+                    });
+
+                    node2.edges.push({
+                        targetNodeId: node1.id,
+                        cost: result.cost,
+                        isInterEdge: false,
+                        innerPath: this.config.cacheInternalPaths ? [...globalPath].reverse() : null
+                    });
+                }
+                // 如果路径不存在，不创建边（集群内不连通）
             }
         }
+    }
+
+    /**
+     * @zh 按需计算 intra-edge 的真实路径
+     * @en Compute actual path for intra-edge on demand
+     */
+    private computeIntraEdgePath(
+        fromNode: AbstractNode,
+        toNode: AbstractNode,
+        edge: AbstractEdge
+    ): { cost: number; path: number[] } | null {
+        const cluster = this.clusters[fromNode.clusterId];
+        if (!cluster) return null;
+
+        // 检查集群缓存
+        const cachedPath = cluster.getCachedPath(fromNode.id, toNode.id);
+        const cachedCost = cluster.getCachedDistance(fromNode.id, toNode.id);
+        if (cachedPath && cachedCost !== undefined) {
+            // 更新边的代价和路径
+            edge.cost = cachedCost;
+            (edge as any).innerPath = cachedPath;
+            return { cost: cachedCost, path: cachedPath };
+        }
+
+        // 计算真实路径
+        const subPathfinder = new AStarPathfinder(cluster.subMap);
+        const local1 = cluster.subMap.globalToLocal(fromNode.position.x, fromNode.position.y);
+        const local2 = cluster.subMap.globalToLocal(toNode.position.x, toNode.position.y);
+
+        const result = subPathfinder.findPath(local1.x, local1.y, local2.x, local2.y);
+
+        if (result.found && result.path.length > 0) {
+            // 转换路径为全局 ConcreteNodeId
+            const globalPath: number[] = result.path.map(p => {
+                const global = cluster.subMap.localToGlobal(p.x, p.y);
+                return global.y * this.mapWidth + global.x;
+            });
+
+            // 缓存结果
+            if (this.config.cacheInternalPaths) {
+                cluster.setCache(fromNode.id, toNode.id, result.cost, globalPath);
+                // 也缓存反向路径
+                cluster.setCache(toNode.id, fromNode.id, result.cost, [...globalPath].reverse());
+            }
+
+            // 更新边
+            edge.cost = result.cost;
+            (edge as any).innerPath = globalPath;
+
+            // 更新反向边
+            const reverseEdge = toNode.edges.find(e => e.targetNodeId === fromNode.id);
+            if (reverseEdge) {
+                reverseEdge.cost = result.cost;
+                (reverseEdge as any).innerPath = [...globalPath].reverse();
+            }
+
+            return { cost: result.cost, path: globalPath };
+        }
+
+        return null;
     }
 
     // =========================================================================
     // 搜索方法 | Search Methods
     // =========================================================================
 
+    /**
+     * @zh 获取指定位置的集群
+     * @en Get cluster at position
+     */
     private getClusterAt(x: number, y: number): Cluster | null {
-        const clusterSize = this.config.clusterSize;
-        const cx = Math.floor(x / clusterSize);
-        const cy = Math.floor(y / clusterSize);
-        return this.clusterGrid[cx]?.[cy] ?? null;
-    }
+        const cx = Math.floor(x / this.config.clusterSize);
+        const cy = Math.floor(y / this.config.clusterSize);
 
-    private insertTemporaryNode(
-        x: number,
-        y: number,
-        cluster: Cluster
-    ): AbstractNode[] {
-        const tempNodes: AbstractNode[] = [];
-        const tempNode = this.createAbstractNode({ x, y }, cluster.id, -1);
-        tempNodes.push(tempNode);
-
-        for (const node of this.abstractNodes.values()) {
-            if (node.clusterId === cluster.id && node.id !== tempNode.id) {
-                const cost = this.heuristic({ x, y }, node.position);
-                tempNode.edges.push({ targetNodeId: node.id, cost, isInterEdge: false });
-                node.edges.push({ targetNodeId: tempNode.id, cost, isInterEdge: false });
-            }
-        }
-
-        return tempNodes;
-    }
-
-    private removeTemporaryNodes(nodes: AbstractNode[]): void {
-        for (const node of nodes) {
-            for (const edge of node.edges) {
-                const targetNode = this.abstractNodes.get(edge.targetNodeId);
-                if (targetNode) {
-                    targetNode.edges = targetNode.edges.filter(e => e.targetNodeId !== node.id);
-                }
-            }
-            this.abstractNodes.delete(node.id);
-        }
-    }
-
-    private searchAbstractGraph(
-        startNodes: AbstractNode[],
-        endNodes: AbstractNode[],
-        opts: Required<IPathfindingOptions>
-    ): AbstractNode[] | null {
-        if (startNodes.length === 0 || endNodes.length === 0) {
+        if (cx < 0 || cx >= this.clustersX || cy < 0 || cy >= this.clustersY) {
             return null;
         }
 
-        const endNodeIds = new Set(endNodes.map(n => n.id));
-        const openList = new BinaryHeap<SearchNode>((a, b) => a.f - b.f);
-        const closedSet = new Set<number>();
-
-        for (const startNode of startNodes) {
-            const h = this.heuristic(startNode.position, endNodes[0].position);
-            openList.push({
-                abstractNode: startNode,
-                g: 0,
-                h: h * opts.heuristicWeight,
-                f: h * opts.heuristicWeight,
-                parent: null
-            });
+        const clusterId = this.clusterGrid[cx]?.[cy];
+        if (clusterId === null || clusterId === undefined) {
+            return null;
         }
+
+        return this.clusters[clusterId] || null;
+    }
+
+    /**
+     * @zh 获取受影响的集群
+     * @en Get affected clusters
+     */
+    private getAffectedClusters(minX: number, minY: number, maxX: number, maxY: number): Cluster[] {
+        const affected: Cluster[] = [];
+        const clusterSize = this.config.clusterSize;
+
+        const minCX = Math.floor(minX / clusterSize);
+        const maxCX = Math.floor(maxX / clusterSize);
+        const minCY = Math.floor(minY / clusterSize);
+        const maxCY = Math.floor(maxY / clusterSize);
+
+        for (let cy = minCY; cy <= maxCY; cy++) {
+            for (let cx = minCX; cx <= maxCX; cx++) {
+                if (cx >= 0 && cx < this.clustersX && cy >= 0 && cy < this.clustersY) {
+                    const clusterId = this.clusterGrid[cx]?.[cy];
+                    if (clusterId !== null && clusterId !== undefined) {
+                        affected.push(this.clusters[clusterId]);
+                    }
+                }
+            }
+        }
+
+        return affected;
+    }
+
+    /**
+     * @zh 插入临时节点
+     * @en Insert temporary node
+     */
+    private insertTempNode(x: number, y: number, cluster: Cluster): AbstractNode {
+        const concreteId = y * this.mapWidth + x;
+
+        // 检查是否已存在该位置的节点
+        for (const nodeId of cluster.nodeIds) {
+            const existing = this.abstractNodes.get(nodeId);
+            if (existing && existing.concreteNodeId === concreteId) {
+                return existing;
+            }
+        }
+
+        // 创建临时节点
+        const tempNode: AbstractNode = {
+            id: this.nextNodeId++,
+            position: { x, y },
+            clusterId: cluster.id,
+            concreteNodeId: concreteId,
+            edges: []
+        };
+
+        this.abstractNodes.set(tempNode.id, tempNode);
+        cluster.addNodeId(tempNode.id);
+
+        // 计算到集群内所有其他节点的真实路径
+        const subPathfinder = new AStarPathfinder(cluster.subMap);
+        const localPos = cluster.subMap.globalToLocal(x, y);
+
+        for (const existingNodeId of cluster.nodeIds) {
+            if (existingNodeId === tempNode.id) continue;
+
+            const existingNode = this.abstractNodes.get(existingNodeId);
+            if (!existingNode) continue;
+
+            const targetLocalPos = cluster.subMap.globalToLocal(
+                existingNode.position.x,
+                existingNode.position.y
+            );
+
+            const result = subPathfinder.findPath(
+                localPos.x, localPos.y,
+                targetLocalPos.x, targetLocalPos.y
+            );
+
+            if (result.found && result.path.length > 0) {
+                // 转换路径
+                const globalPath: number[] = result.path.map(p => {
+                    const global = cluster.subMap.localToGlobal(p.x, p.y);
+                    return global.y * this.mapWidth + global.x;
+                });
+
+                // 添加双向边
+                tempNode.edges.push({
+                    targetNodeId: existingNode.id,
+                    cost: result.cost,
+                    isInterEdge: false,
+                    innerPath: globalPath
+                });
+
+                existingNode.edges.push({
+                    targetNodeId: tempNode.id,
+                    cost: result.cost,
+                    isInterEdge: false,
+                    innerPath: [...globalPath].reverse()
+                });
+            }
+        }
+
+        return tempNode;
+    }
+
+    /**
+     * @zh 移除临时节点
+     * @en Remove temporary node
+     */
+    private removeTempNode(node: AbstractNode, cluster: Cluster): void {
+        // 移除其他节点指向此节点的边
+        for (const existingNodeId of cluster.nodeIds) {
+            if (existingNodeId === node.id) continue;
+
+            const existingNode = this.abstractNodes.get(existingNodeId);
+            if (existingNode) {
+                existingNode.edges = existingNode.edges.filter(
+                    e => e.targetNodeId !== node.id
+                );
+            }
+        }
+
+        // 从集群和图中移除
+        cluster.removeNodeId(node.id);
+        this.abstractNodes.delete(node.id);
+    }
+
+    /**
+     * @zh 在抽象图上进行 A* 搜索
+     * @en Perform A* search on abstract graph
+     */
+    private abstractSearch(
+        startNode: AbstractNode,
+        endNode: AbstractNode,
+        opts: Required<IPathfindingOptions>
+    ): AbstractNode[] | null {
+        const openList = new IndexedBinaryHeap<SearchNode>((a, b) => a.f - b.f);
+        const nodeMap = new Map<number, SearchNode>();
+
+        const endPosition = endNode.position;
+
+        // 初始化起点
+        const h = this.heuristic(startNode.position, endPosition) * opts.heuristicWeight;
+        const startSearchNode: SearchNode = {
+            node: startNode,
+            g: 0,
+            h,
+            f: h,
+            parent: null,
+            closed: false,
+            opened: true,
+            heapIndex: -1
+        };
+
+        openList.push(startSearchNode);
+        nodeMap.set(startNode.id, startSearchNode);
 
         let nodesSearched = 0;
 
         while (!openList.isEmpty && nodesSearched < opts.maxNodes) {
             const current = openList.pop()!;
+            current.closed = true;
             nodesSearched++;
 
-            if (endNodeIds.has(current.abstractNode.id)) {
-                return this.reconstructAbstractPath(current);
+            // 找到目标
+            if (current.node.id === endNode.id) {
+                return this.reconstructPath(current);
             }
 
-            if (closedSet.has(current.abstractNode.id)) {
-                continue;
-            }
-            closedSet.add(current.abstractNode.id);
+            // 扩展邻居
+            for (const edge of current.node.edges) {
+                let neighbor = nodeMap.get(edge.targetNodeId);
 
-            for (const edge of current.abstractNode.edges) {
-                if (closedSet.has(edge.targetNodeId)) {
-                    continue;
+                if (!neighbor) {
+                    const neighborNode = this.abstractNodes.get(edge.targetNodeId);
+                    if (!neighborNode) continue;
+
+                    const nh = this.heuristic(neighborNode.position, endPosition) * opts.heuristicWeight;
+                    neighbor = {
+                        node: neighborNode,
+                        g: Infinity,
+                        h: nh,
+                        f: Infinity,
+                        parent: null,
+                        closed: false,
+                        opened: false,
+                        heapIndex: -1
+                    };
+                    nodeMap.set(edge.targetNodeId, neighbor);
                 }
 
-                const neighbor = this.abstractNodes.get(edge.targetNodeId);
-                if (!neighbor) continue;
+                if (neighbor.closed) continue;
 
                 const tentativeG = current.g + edge.cost;
-                const h = this.heuristic(neighbor.position, endNodes[0].position) * opts.heuristicWeight;
 
-                openList.push({
-                    abstractNode: neighbor,
-                    g: tentativeG,
-                    h,
-                    f: tentativeG + h,
-                    parent: current
-                });
+                if (!neighbor.opened) {
+                    neighbor.g = tentativeG;
+                    neighbor.f = tentativeG + neighbor.h;
+                    neighbor.parent = current;
+                    neighbor.opened = true;
+                    openList.push(neighbor);
+                } else if (tentativeG < neighbor.g) {
+                    neighbor.g = tentativeG;
+                    neighbor.f = tentativeG + neighbor.h;
+                    neighbor.parent = current;
+                    openList.update(neighbor);
+                }
             }
         }
 
         return null;
     }
 
-    private reconstructAbstractPath(endNode: SearchNode): AbstractNode[] {
+    /**
+     * @zh 重建抽象路径
+     * @en Reconstruct abstract path
+     */
+    private reconstructPath(endNode: SearchNode): AbstractNode[] {
         const path: AbstractNode[] = [];
         let current: SearchNode | null = endNode;
 
         while (current) {
-            path.unshift(current.abstractNode);
+            path.unshift(current.node);
             current = current.parent;
         }
 
         return path;
     }
 
+    /**
+     * @zh 细化抽象路径为具体路径
+     * @en Refine abstract path to concrete path
+     */
     private refinePath(
         abstractPath: AbstractNode[],
         startX: number,
@@ -651,53 +1366,111 @@ export class HPAPathfinder implements IPathfinder {
         endY: number,
         opts: Required<IPathfindingOptions>
     ): IPathResult {
+        if (abstractPath.length === 0) {
+            return EMPTY_PATH_RESULT;
+        }
+
         const fullPath: IPoint[] = [];
         let totalCost = 0;
         let nodesSearched = abstractPath.length;
 
-        let currentX = startX;
-        let currentY = startY;
+        // 处理抽象路径中的每一段
+        for (let i = 0; i < abstractPath.length - 1; i++) {
+            const fromNode = abstractPath[i];
+            const toNode = abstractPath[i + 1];
 
-        for (let i = 0; i < abstractPath.length; i++) {
-            const node = abstractPath[i];
-            const targetX = i === abstractPath.length - 1 ? endX : node.position.x;
-            const targetY = i === abstractPath.length - 1 ? endY : node.position.y;
+            // 查找连接边
+            const edge = fromNode.edges.find(e => e.targetNodeId === toNode.id);
 
-            if (currentX !== targetX || currentY !== targetY) {
-                const segment = this.localPathfinder.findPath(currentX, currentY, targetX, targetY, opts);
+            if (!edge) {
+                // 边不存在，需要实时计算
+                const segResult = this.findLocalPath(
+                    fromNode.position.x, fromNode.position.y,
+                    toNode.position.x, toNode.position.y,
+                    opts
+                );
 
-                if (!segment.found) {
-                    if (fullPath.length > 0) {
-                        return {
-                            found: true,
-                            path: fullPath,
-                            cost: totalCost,
-                            nodesSearched
-                        };
+                if (segResult.found) {
+                    this.appendPath(fullPath, segResult.path);
+                    totalCost += segResult.cost;
+                    nodesSearched += segResult.nodesSearched;
+                }
+            } else if (edge.isInterEdge) {
+                // Inter-edge：直接连接
+                if (fullPath.length === 0 ||
+                    fullPath[fullPath.length - 1].x !== fromNode.position.x ||
+                    fullPath[fullPath.length - 1].y !== fromNode.position.y) {
+                    fullPath.push({ x: fromNode.position.x, y: fromNode.position.y });
+                }
+                fullPath.push({ x: toNode.position.x, y: toNode.position.y });
+                totalCost += edge.cost;
+            } else if (edge.innerPath && edge.innerPath.length > 0) {
+                // Intra-edge：使用缓存路径
+                const concretePath = edge.innerPath.map(id => ({
+                    x: id % this.mapWidth,
+                    y: Math.floor(id / this.mapWidth)
+                }));
+                this.appendPath(fullPath, concretePath);
+                totalCost += edge.cost;
+            } else {
+                // Lazy intra-edge 或没有缓存路径：按需计算真实路径
+                // Lazy intra-edge or no cached path: compute actual path on demand
+                const computed = this.computeIntraEdgePath(fromNode, toNode, edge);
+
+                if (computed && computed.path.length > 0) {
+                    // 使用计算出的路径
+                    const concretePath = computed.path.map(id => ({
+                        x: id % this.mapWidth,
+                        y: Math.floor(id / this.mapWidth)
+                    }));
+                    this.appendPath(fullPath, concretePath);
+                    totalCost += computed.cost;
+                } else {
+                    // 路径计算失败，回退到实时搜索
+                    // Path computation failed, fall back to real-time search
+                    const segResult = this.findLocalPath(
+                        fromNode.position.x, fromNode.position.y,
+                        toNode.position.x, toNode.position.y,
+                        opts
+                    );
+
+                    if (segResult.found) {
+                        this.appendPath(fullPath, segResult.path);
+                        totalCost += segResult.cost;
+                        nodesSearched += segResult.nodesSearched;
                     }
-                    return EMPTY_PATH_RESULT;
                 }
-
-                for (let j = fullPath.length === 0 ? 0 : 1; j < segment.path.length; j++) {
-                    fullPath.push(segment.path[j]);
-                }
-
-                totalCost += segment.cost;
-                nodesSearched += segment.nodesSearched;
             }
-
-            currentX = targetX;
-            currentY = targetY;
         }
 
-        if (currentX !== endX || currentY !== endY) {
-            const finalSegment = this.localPathfinder.findPath(currentX, currentY, endX, endY, opts);
-            if (finalSegment.found) {
-                for (let j = 1; j < finalSegment.path.length; j++) {
-                    fullPath.push(finalSegment.path[j]);
+        // 确保起点正确
+        if (fullPath.length > 0 && (fullPath[0].x !== startX || fullPath[0].y !== startY)) {
+            // 连接起点到路径开头
+            const firstPoint = fullPath[0];
+            if (Math.abs(firstPoint.x - startX) <= 1 && Math.abs(firstPoint.y - startY) <= 1) {
+                fullPath.unshift({ x: startX, y: startY });
+            } else {
+                const segResult = this.findLocalPath(startX, startY, firstPoint.x, firstPoint.y, opts);
+                if (segResult.found) {
+                    fullPath.splice(0, 0, ...segResult.path.slice(0, -1));
+                    totalCost += segResult.cost;
                 }
-                totalCost += finalSegment.cost;
-                nodesSearched += finalSegment.nodesSearched;
+            }
+        }
+
+        // 确保终点正确
+        if (fullPath.length > 0) {
+            const lastPoint = fullPath[fullPath.length - 1];
+            if (lastPoint.x !== endX || lastPoint.y !== endY) {
+                if (Math.abs(lastPoint.x - endX) <= 1 && Math.abs(lastPoint.y - endY) <= 1) {
+                    fullPath.push({ x: endX, y: endY });
+                } else {
+                    const segResult = this.findLocalPath(lastPoint.x, lastPoint.y, endX, endY, opts);
+                    if (segResult.found) {
+                        fullPath.push(...segResult.path.slice(1));
+                        totalCost += segResult.cost;
+                    }
+                }
             }
         }
 
@@ -709,10 +1482,32 @@ export class HPAPathfinder implements IPathfinder {
         };
     }
 
-    // =========================================================================
-    // 辅助方法 | Helper Methods
-    // =========================================================================
+    /**
+     * @zh 追加路径（避免重复点）
+     * @en Append path (avoid duplicate points)
+     */
+    private appendPath(fullPath: IPoint[], segment: readonly IPoint[]): void {
+        if (segment.length === 0) return;
 
+        let startIdx = 0;
+
+        // 避免重复第一个点
+        if (fullPath.length > 0) {
+            const last = fullPath[fullPath.length - 1];
+            if (last.x === segment[0].x && last.y === segment[0].y) {
+                startIdx = 1;
+            }
+        }
+
+        for (let i = startIdx; i < segment.length; i++) {
+            fullPath.push({ x: segment[i].x, y: segment[i].y });
+        }
+    }
+
+    /**
+     * @zh 局部寻路
+     * @en Local pathfinding
+     */
     private findLocalPath(
         startX: number,
         startY: number,
@@ -723,41 +1518,10 @@ export class HPAPathfinder implements IPathfinder {
         return this.localPathfinder.findPath(startX, startY, endX, endY, opts);
     }
 
-    private findInternalPath(
-        startX: number,
-        startY: number,
-        endX: number,
-        endY: number,
-        cluster: Cluster
-    ): IPoint[] | null {
-        const cacheKey = `${cluster.id}:${startX},${startY}->${endX},${endY}`;
-
-        if (this.config.cacheInternalPaths) {
-            const cached = this.internalPathCache.get(cacheKey);
-            if (cached) {
-                return cached;
-            }
-        }
-
-        const result = this.localPathfinder.findPath(startX, startY, endX, endY);
-
-        if (result.found && this.config.cacheInternalPaths) {
-            this.internalPathCache.set(cacheKey, [...result.path]);
-        }
-
-        return result.found ? [...result.path] : null;
-    }
-
-    private calculatePathCost(path: IPoint[]): number {
-        let cost = 0;
-        for (let i = 1; i < path.length; i++) {
-            const dx = Math.abs(path[i].x - path[i - 1].x);
-            const dy = Math.abs(path[i].y - path[i - 1].y);
-            cost += dx !== 0 && dy !== 0 ? Math.SQRT2 : 1;
-        }
-        return cost;
-    }
-
+    /**
+     * @zh 启发式函数（Octile 距离）
+     * @en Heuristic function (Octile distance)
+     */
     private heuristic(a: IPoint, b: IPoint): number {
         const dx = Math.abs(a.x - b.x);
         const dy = Math.abs(a.y - b.y);


### PR DESCRIPTION
## Summary
- **HPA* Lazy Intra-Edges**: 延迟集群内路径计算到首次查询，预处理时间从 ~68s 降至 ~52ms
- **入口节点分布优化**: 修复宽边界只在两端放置节点的问题，现在均匀分布，路径质量接近 A*
- **交互式文档演示**: 添加 A*、HPA*、算法对比等可交互 demo 页面
- **Demo Bundle 包**: 新增 `@esengine/demo-bundle` 用于文档 playground

## Test plan
- [x] 所有 397 个测试通过
- [x] HPA* 在开放地图上路径偏差为 0（之前偏差 19）
- [x] 预处理性能提升 1300 倍（68s → 52ms）
- [x] 交互式 demo 页面可正常运行