### PR TITLE
fix(pathfinding): 修复坐标转换和寻路失败时的行为问题

### DIFF
--- a/.changeset/fix-cellsize-coordinate-conversion.md
+++ b/.changeset/fix-cellsize-coordinate-conversion.md
@@ -1,0 +1,48 @@
+---
+"@esengine/pathfinding": patch
+---
+
+fix(pathfinding): 修复坐标转换和寻路失败时的行为问题
+
+## 修复 1: cellSize=1 时路径坐标返回 0.5 倍数
+
+### 问题
+当 `cellSize=1` 时，`toPixelCoord` 方法会在网格坐标基础上添加 0.5 的偏移（单元格中心），
+导致返回的路径坐标都是 0.5 的倍数（如 0.5, 1.5, 2.5...），而不是预期的整数坐标。
+
+### 解决方案
+- 新增 `alignToCenter` 配置选项，允许用户显式控制是否返回单元格中心
+- 默认行为：`cellSize > 1` 时对齐中心，`cellSize = 1` 时不对齐
+- 添加 `cellSize`、`width`、`height`、`cost` 等参数的验证，防止无效值
+
+### 新增 API
+```typescript
+interface IGridPathfinderAdapterConfig {
+    cellSize?: number;
+    alignToCenter?: boolean;  // 新增：是否对齐到单元格中心
+}
+```
+
+### 使用示例
+```typescript
+// 默认行为（推荐）
+const planner1 = createAStarPlanner(gridMap);  // cellSize=1, alignToCenter=false
+const planner2 = createAStarPlanner(gridMap, undefined, { cellSize: 20 });  // alignToCenter=true
+
+// 显式覆盖
+const planner3 = createAStarPlanner(gridMap, undefined, {
+    cellSize: 20,
+    alignToCenter: false  // 禁用中心对齐
+});
+```
+
+## 修复 2: 寻路失败时代理直线穿墙
+
+### 问题
+当寻路失败（目标不可达）时，代理的 path 被清空，但 `calculatePreferredVelocity`
+会直接使用 `destination` 作为目标，导致代理直线穿过障碍物走向目标。
+
+### 解决方案
+- 检查代理状态，`Unreachable` 或 `Arrived` 时返回零速度
+- 检查路径是否为空，无路径且非计算中时返回零速度
+- 只有当路径存在时才计算期望速度

--- a/docs/src/content/docs/en/modules/pathfinding/grid-map.md
+++ b/docs/src/content/docs/en/modules/pathfinding/grid-map.md
@@ -178,8 +178,23 @@ console.log(result.path);
 
 **Conversion rules**:
 - Pixel → Grid: `Math.floor(pixel / cellSize)`
-- Grid → Pixel: `grid * cellSize + cellSize * 0.5` (returns cell center)
+- Grid → Pixel:
+  - When `cellSize > 1`: `grid * cellSize + cellSize * 0.5` (returns cell center)
+  - When `cellSize = 1`: `grid` (returns grid coordinate directly, no offset)
+
+**alignToCenter option**:
+
+You can explicitly control whether to return cell center using `alignToCenter`:
+
+```typescript
+// Disable center alignment (returns cell top-left corner)
+const planner = createAStarPlanner(gridMap, undefined, {
+    cellSize: 20,
+    alignToCenter: false
+});
+```
 
 **Without cellSize (default value 1)**:
 - Input coordinates are used directly as grid indices
+- Output coordinates are also integer grid coordinates (no 0.5 offset)
 - Suitable when game logic already uses grid coordinates

--- a/docs/src/content/docs/en/modules/pathfinding/navigation-system.md
+++ b/docs/src/content/docs/en/modules/pathfinding/navigation-system.md
@@ -262,7 +262,30 @@ nav.setDestination(480, 300);
 
 **Conversion rules**:
 - Pixel → Grid: `Math.floor(pixel / cellSize)`
-- Grid → Pixel: `grid * cellSize + cellSize * 0.5` (returns cell center)
+- Grid → Pixel:
+  - When `cellSize > 1`: `grid * cellSize + cellSize * 0.5` (returns cell center)
+  - When `cellSize = 1`: `grid` (returns grid coordinate directly)
+
+**alignToCenter option**:
+
+You can explicitly control whether to return cell center using `alignToCenter`:
+
+```typescript
+// Default behavior: align to center when cellSize > 1, no alignment when cellSize = 1
+const planner1 = createAStarPlanner(gridMap, undefined, { cellSize: 20 });  // alignToCenter = true
+
+// Explicitly disable center alignment (returns cell top-left corner)
+const planner2 = createAStarPlanner(gridMap, undefined, {
+    cellSize: 20,
+    alignToCenter: false
+});
+
+// Explicitly enable center alignment (returns 0.5, 1.5, 2.5... even when cellSize = 1)
+const planner3 = createAStarPlanner(gridMap, undefined, {
+    cellSize: 1,
+    alignToCenter: true
+});
+```
 
 ### Time-Sliced Pathfinding (Large-Scale Agents)
 

--- a/docs/src/content/docs/modules/pathfinding/grid-map.md
+++ b/docs/src/content/docs/modules/pathfinding/grid-map.md
@@ -178,8 +178,23 @@ console.log(result.path);
 
 **转换规则**：
 - 像素 → 网格：`Math.floor(pixel / cellSize)`
-- 网格 → 像素：`grid * cellSize + cellSize * 0.5`（返回单元格中心）
+- 网格 → 像素：
+  - 当 `cellSize > 1` 时：`grid * cellSize + cellSize * 0.5`（返回单元格中心）
+  - 当 `cellSize = 1` 时：`grid`（直接返回网格坐标，无偏移）
+
+**alignToCenter 选项**：
+
+可以通过 `alignToCenter` 显式控制是否返回单元格中心：
+
+```typescript
+// 禁用中心对齐（返回单元格左上角）
+const planner = createAStarPlanner(gridMap, undefined, {
+    cellSize: 20,
+    alignToCenter: false
+});
+```
 
 **不设置 cellSize（默认值 1）**：
 - 输入坐标直接作为网格索引使用
+- 输出坐标也是整数网格坐标（无 0.5 偏移）
 - 适用于游戏逻辑已经使用网格坐标的情况

--- a/docs/src/content/docs/modules/pathfinding/navigation-system.md
+++ b/docs/src/content/docs/modules/pathfinding/navigation-system.md
@@ -257,7 +257,30 @@ nav.setDestination(480, 300);
 
 **转换规则**：
 - 像素 → 网格：`Math.floor(pixel / cellSize)`
-- 网格 → 像素：`grid * cellSize + cellSize * 0.5`（返回单元格中心）
+- 网格 → 像素：
+  - 当 `cellSize > 1` 时：`grid * cellSize + cellSize * 0.5`（返回单元格中心）
+  - 当 `cellSize = 1` 时：`grid`（直接返回网格坐标）
+
+**alignToCenter 选项**：
+
+可以通过 `alignToCenter` 显式控制是否返回单元格中心：
+
+```typescript
+// 默认行为：cellSize > 1 时对齐中心，cellSize = 1 时不对齐
+const planner1 = createAStarPlanner(gridMap, undefined, { cellSize: 20 });  // alignToCenter = true
+
+// 显式禁用中心对齐（返回单元格左上角坐标）
+const planner2 = createAStarPlanner(gridMap, undefined, {
+    cellSize: 20,
+    alignToCenter: false
+});
+
+// 显式启用中心对齐（cellSize = 1 时也返回 0.5, 1.5, 2.5...）
+const planner3 = createAStarPlanner(gridMap, undefined, {
+    cellSize: 1,
+    alignToCenter: true
+});
+```
 
 ### 时间切片寻路（大规模代理）
 

--- a/packages/framework/pathfinding/src/ecs/NavigationSystem.ts
+++ b/packages/framework/pathfinding/src/ecs/NavigationSystem.ts
@@ -877,6 +877,18 @@ export class NavigationSystem extends EntitySystem {
             return { x: 0, y: 0 };
         }
 
+        // 如果代理处于无法到达或已到达状态，停止移动
+        // If agent is unreachable or arrived, stop moving
+        if (agent.state === NavigationState.Unreachable || agent.state === NavigationState.Arrived) {
+            return { x: 0, y: 0 };
+        }
+
+        // 如果没有路径且不在计算中，停止移动（避免直线穿墙）
+        // If no path and not computing, stop moving (avoid walking through walls)
+        if (agent.path.length === 0 && !agent.isComputingPath) {
+            return { x: 0, y: 0 };
+        }
+
         let targetX: number, targetY: number;
         let isLastWaypoint = false;
 
@@ -885,10 +897,16 @@ export class NavigationSystem extends EntitySystem {
             targetX = waypoint.x;
             targetY = waypoint.y;
             isLastWaypoint = agent.currentWaypointIndex === agent.path.length - 1;
-        } else {
+        } else if (agent.path.length > 0) {
+            // 路径已走完，使用最终目标
+            // Path exhausted, use final destination
             targetX = agent.destination.x;
             targetY = agent.destination.y;
             isLastWaypoint = true;
+        } else {
+            // 没有路径，不应该移动
+            // No path, should not move
+            return { x: 0, y: 0 };
         }
 
         const dx = targetX - agent.position.x;

--- a/packages/framework/pathfinding/src/grid/GridMap.ts
+++ b/packages/framework/pathfinding/src/grid/GridMap.ts
@@ -129,6 +129,12 @@ export class GridMap implements IPathfindingMap {
     private readonly options: Required<IGridMapOptions>;
 
     constructor(width: number, height: number, options?: IGridMapOptions) {
+        if (width <= 0 || !Number.isFinite(width) || !Number.isInteger(width)) {
+            throw new Error(`width must be a positive integer, got: ${width}`);
+        }
+        if (height <= 0 || !Number.isFinite(height) || !Number.isInteger(height)) {
+            throw new Error(`height must be a positive integer, got: ${height}`);
+        }
         this.width = width;
         this.height = height;
         this.options = { ...DEFAULT_GRID_OPTIONS, ...options };
@@ -194,8 +200,16 @@ export class GridMap implements IPathfindingMap {
     /**
      * @zh 设置位置的移动代价
      * @en Set movement cost at position
+     *
+     * @param x - @zh X 坐标 @en X coordinate
+     * @param y - @zh Y 坐标 @en Y coordinate
+     * @param cost - @zh 移动代价，必须为正数 @en Movement cost, must be positive
+     * @throws @zh 如果 cost 不是正数则抛出错误 @en Throws if cost is not positive
      */
     setCost(x: number, y: number, cost: number): void {
+        if (cost <= 0 || !Number.isFinite(cost)) {
+            throw new Error(`cost must be a positive finite number, got: ${cost}`);
+        }
         const node = this.getNodeAt(x, y);
         if (node) {
             node.cost = cost;


### PR DESCRIPTION
## Summary
- 修复 `cellSize=1` 时路径坐标返回 0.5 倍数的问题
- 修复寻路失败时代理直线穿墙的问题
- 新增 `alignToCenter` 配置选项，允许显式控制是否返回单元格中心
- 添加参数验证，防止无效的 `cellSize`、`width`、`height`、`cost` 值

## Changes

### Fix 1: cellSize=1 时路径坐标返回 0.5 倍数
**问题**: 当 `cellSize=1` 时，`toPixelCoord` 方法会在网格坐标基础上添加 0.5 的偏移（单元格中心），导致返回的路径坐标都是 0.5 的倍数（如 0.5, 1.5, 2.5...）

**解决方案**:
- 新增 `alignToCenter` 配置选项
- 默认行为：`cellSize > 1` 时对齐中心，`cellSize = 1` 时不对齐
- 用户可显式覆盖此默认行为

### Fix 2: 寻路失败时代理直线穿墙
**问题**: 当寻路失败（目标不可达）时，代理的 path 被清空，但 `calculatePreferredVelocity` 会直接使用 `destination` 作为目标，导致代理直线穿过障碍物

**解决方案**:
- 检查代理状态，`Unreachable` 或 `Arrived` 时返回零速度
- 检查路径是否为空，无路径且非计算中时返回零速度

## Test plan
- [x] 单元测试通过
- [x] 类型检查通过
- [x] 手动测试 cellSize=1 场景
- [x] 手动测试寻路失败场景

## Files changed
- `packages/framework/pathfinding/src/ecs/adapters/GridPathfinderAdapter.ts`
- `packages/framework/pathfinding/src/ecs/adapters/IncrementalGridPathPlannerAdapter.ts`
- `packages/framework/pathfinding/src/grid/GridMap.ts`
- `packages/framework/pathfinding/src/ecs/NavigationSystem.ts`
- `docs/src/content/docs/modules/pathfinding/navigation-system.md`
- `docs/src/content/docs/en/modules/pathfinding/navigation-system.md`
- `docs/src/content/docs/modules/pathfinding/grid-map.md`
- `docs/src/content/docs/en/modules/pathfinding/grid-map.md`
- `docs/public/js/esengine.iife.js`